### PR TITLE
Enhancing quality of thumbnails

### DIFF
--- a/core/src/capture/capturer.rs
+++ b/core/src/capture/capturer.rs
@@ -21,8 +21,8 @@ use stream::{Stream, StreamRuntimeMessage};
 
 // Constants for magic numbers
 const JPEG_QUALITY: u8 = 70;
-const THUMBNAIL_WIDTH: f64 = 480.0;
-const THUMBNAIL_HEIGHT: f64 = 360.0;
+const THUMBNAIL_WIDTH: f64 = 1280.0;
+const THUMBNAIL_HEIGHT: f64 = 720.0;
 const SCREENSHOT_CAPTURE_SLEEP_MS: u64 = 33;
 const MAX_SCREENSHOT_RETRY_ATTEMPTS: u32 = 100;
 const MAX_STREAM_FAILURES_BEFORE_EXIT: u64 = 5;


### PR DESCRIPTION
This PR includes:

1. Setting the target size of the screenshot to 1280 x 720, this is size of the thumbnails used for crisper image quality.