### PR TITLE
fix: conditionally bring to front screen share window

### DIFF
--- a/tauri/src/components/ui/call-center.tsx
+++ b/tauri/src/components/ui/call-center.tsx
@@ -433,7 +433,7 @@ function ScreensharingEventListener({
 
     if (trackFound) {
       updateRole(ParticipantRole.CONTROLLER);
-      tauriUtils.createScreenShareWindow(callTokens.videoToken);
+      tauriUtils.createScreenShareWindow(callTokens.videoToken, false);
     } else if (screenshareTrackFound) {
       if (!trackFound && callTokens?.role === ParticipantRole.CONTROLLER) {
         tauriUtils.closeScreenShareWindow();

--- a/tauri/src/windows/window-utils.ts
+++ b/tauri/src/windows/window-utils.ts
@@ -9,13 +9,13 @@ getVersion().then((version) => {
   appVersion = version;
 });
 
-const createScreenShareWindow = async (videoToken: string) => {
+const createScreenShareWindow = async (videoToken: string, bringToFront: boolean = true) => {
   const URL = `screenshare.html?videoToken=${videoToken}`;
 
   // Check if there is already a window open,
   // then focus on it and bring it to the front
   const isWindowOpen = await WebviewWindow.getByLabel("screenshare");
-  if (isWindowOpen) {
+  if (isWindowOpen && bringToFront) {
     await isWindowOpen.setFocus();
     return;
   }


### PR DESCRIPTION
Changes `ScreensharingEventListener` to not bring the screen share to the front when it is already open. Changes to the tracks could bring it to the front when the user doesn't want to.

Addresses #50.