### PR TITLE
Disable context menu by default in prod

### DIFF
--- a/tauri/src/lib/hooks.ts
+++ b/tauri/src/lib/hooks.ts
@@ -44,7 +44,7 @@ export const useDisableNativeContextMenu = () => {
 
     document.addEventListener("contextmenu", (event) => {
       if (import.meta.env.MODE === "development") return;
-      if (!isDevToolsEnabled) return;
+      if (isDevToolsEnabled) return;
       event.preventDefault();
     });
   }, []);


### PR DESCRIPTION
This PR Fixes #23 
bug: context menu useDisableNativeContextMenu is enabled in prod by default 

Closes #23 