### PR TITLE
feat: auto-generate release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,96 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+[remote.github]
+owner = "gethopp"
+repo = "hopp"
+
+[changelog]
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }} by {% if commit.remote.username %}[@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){% else %}{{ commit.author.name }}{% endif %}\
+            {%- if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}](https://github.com/gethopp/hopp/pull/{{ commit.remote.pr_number }}){% endif -%}\
+    {% endfor %}
+{% endfor %}
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace the placeholder <REPO> with a URL.
+    #{ pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" },
+]
+# render body even when there are no releases to process
+# render_always = true
+# output file path
+# output = "test.md"
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = true
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Replace issue numbers with link templates to be updated in `changelog.postprocessors`.
+    #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the commit message using https://github.com/crate-ci/typos.
+    # If the spelling is incorrect, it will be fixed automatically.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = false
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    { message = ".*", group = "<!-- 10 -->💼 Other" },
+]
+# Exclude commits that are not matched by any commit parser.
+filter_commits = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = []
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order releases topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false


### PR DESCRIPTION
To run this we should target the range commits:
`git-cliff 7ad0eec316c06fccb97b9104b3cffaa5fcc631d3..HEAD --output temp.MD`


At some point, we can make it fully automated, when we migrate the https://github.com/gethopp/hopp-releases to this repo. 

Example output:
```
### 🚀 Features

- Implement camera feature 📹 (#59) by [@konsalex](https://github.com/konsalex) in [#59](https://github.com/gethopp/hopp/pull/59)

### 🐛 Bug Fixes

- *(frontend)* Fix role transitions by [@iparaskev](https://github.com/iparaskev)
- *(core)* Controller overwriting sharer's remote control flag (#65) by [@iparaskev](https://github.com/iparaskev) in [#65](https://github.com/gethopp/hopp/pull/65)
- Bring content picker to front (#57) by [@konsalex](https://github.com/konsalex) in [#57](https://github.com/gethopp/hopp/pull/57)
- Add camera entitlement by [@iparaskev](https://github.com/iparaskev)
- Change permission request mic/camera by [@iparaskev](https://github.com/iparaskev)
- Camera bugs by [@iparaskev](https://github.com/iparaskev)
- *(frontend)* Don't open camera window without a track by [@iparaskev](https://github.com/iparaskev)
- Stop debug call sound on unmount (#72) by [@theodkp](https://github.com/theodkp) in [#72](https://github.com/gethopp/hopp/pull/72)

### 💼 Other

- Allow screen sharing when accessibility permission is not set (#68) by [@iparaskev](https://github.com/iparaskev) in [#68](https://github.com/gethopp/hopp/pull/68)

### ⚙️ Miscellaneous Tasks

- Git lang stats by [@konsalex](https://github.com/konsalex)
- Bump release by [@iparaskev](https://github.com/iparaskev)
- Lower camera res by [@iparaskev](https://github.com/iparaskev)
```