### PR TITLE
fix: reduce entry padding when selecting content for sharing

### DIFF
--- a/tauri/src/windows/contentPicker/main.tsx
+++ b/tauri/src/windows/contentPicker/main.tsx
@@ -157,7 +157,7 @@ function Window() {
         className="title-panel h-[28px] top-0 left-0 titlebar w-full bg-slate-900 flex flex-row justify-end pr-4"
       ></div>
       {!accessibilityPermission && (
-        <div className="flex flex-row items-center justify-center gap-2 px-4 py-2 mt-2">
+        <div className="flex flex-row items-center justify-center gap-2 px-2 py-2 mt-1">
           <span className="text-center text-base font-medium text-yellow-400">
             ⚠️ Accessibility permission is not granted, remote control will not work
           </span>
@@ -166,7 +166,7 @@ function Window() {
           </Button>
         </div>
       )}
-      <div className="flex flex-col items-start gap-2 px-4 py-2 mt-2">
+      <div className="flex flex-col items-start gap-2 px-2 py-2 mt-1">
         <span className="mr-2 small">Choose resolution:</span>
         <Select onValueChange={updateResolution} value={resolution}>
           <SelectTrigger className="w-[180px]">
@@ -182,7 +182,7 @@ function Window() {
         </Select>
       </div>
       <div
-        className={clsx("content px-4 pb-4 pt-[10px] overflow-auto gap-4", {
+        className={clsx("content px-2 pb-2 pt-[8px] overflow-auto gap-3", {
           "h-full flex flex-col justify-center": hasClicked,
           "grid grid-cols-2 h-full": !hasClicked,
         })}
@@ -208,7 +208,7 @@ function Window() {
         : content.map((item) => (
             <div
               key={item.content.id}
-              className="flex flex-col group items-start gap-3 cursor-pointer transition-all duration-300 hover:bg-slate-500 p-2 rounded-md"
+              className="flex flex-col group items-start gap-2 cursor-pointer transition-all duration-300 hover:bg-slate-500 p-1 rounded-md"
               onClick={() => handleItemClick(item.content)}
             >
               <AspectRatio ratio={16 / 9}>
@@ -218,7 +218,7 @@ function Window() {
                   className="w-full max-h-full object-contain rounded-md group-hover:scale-[100.5%] transition-all duration-300 overflow-hidden bg-slate-600 bg-opacity-40"
                 />
               </AspectRatio>
-              <span className="text-center small ml-0.5">{`${item.title}`}</span>
+              <span className="text-center small">{`${item.title}`}</span>
             </div>
           ))
         }


### PR DESCRIPTION
## Description
Reduces excessive padding in the content picker window to provide more space for content previews while maintaining clean spacing.

## Changes Made
- Reduce container padding from `px-4` to `px-2` for more content space
- Reduce individual item padding from `p-2` to `p-1`  
- Reduce gaps between items from `gap-4` to `gap-3`
- Remove unnecessary margin from title text
- Reduce padding in resolution selector and accessibility warning areas

## Impact
- Content previews are now larger and easier to see
- Better space utilization while maintaining visual hierarchy
- Improved user experience for screen sharing selection

## Testing
- [x] Code compiles without errors
- [x] Changes maintain existing functionality
- [x] Responsive design preserved
- [x] No accessibility issues introduced

Fixes #114