### PR TITLE
chore: sentry issues

### DIFF
--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -62,7 +62,8 @@
         "skipTaskbar": true,
         "alwaysOnTop": true,
         "useHttpsScheme": true,
-        "dragDropEnabled": false
+        "dragDropEnabled": false,
+        "additionalBrowserArgs": "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --autoplay-policy=no-user-gesture-required"
       }
     ]
   }

--- a/tauri/src/services/socket.ts
+++ b/tauri/src/services/socket.ts
@@ -86,7 +86,7 @@ class SocketService {
     });
 
     this.socket.addEventListener("error", (event: Event) => {
-      console.error("Socket connection error:", event);
+      console.error("Socket connection error:", JSON.stringify(event));
       useStore.getState().setSocketConnected(false);
     });
 


### PR DESCRIPTION
Tackles two repeating issues:
1. For websockets, just stringify message so we can get better observability of what is happening. Example issue:
https://renkey.sentry.io/issues/41753924/events/eee8ecc618f04c198b2f0dc5de3d2ee7/?project=4508859901476944&referrer=event-or-group-header#contexts

As of today, the error is not stringified thus, we have no visibility:
```
Socket connection error:,
{
currentTarget: [object EventTarget],
isTrusted: false,
target: [object EventTarget],
type: error
}
],
```

2. Around [this error](https://renkey.sentry.io/issues/64176996/?project=4508859901476944&query=is%3Aunresolved&referrer=issue-stream), this was reccuring a lot, and while I was searching to see if we can bubble up the error and capture it, found that we skipped passing the `additionalbrowserargs` with the gesture requirement disabled. After the next release, in theory we should not see the issue anymore.

Related ones: https://github.com/search?type=code&q=%22no-user-gesture-required%22+path%3A*.json 