### PR TITLE
improvement(sentry): Use send_envelope in simple_event function

### DIFF
--- a/core/sentry_utils/src/lib.rs
+++ b/core/sentry_utils/src/lib.rs
@@ -146,7 +146,8 @@ pub fn simple_event(message: String) {
         tags,
         ..Default::default()
     };
-    client.capture_event(event, None);
+    let envelope: Envelope = event.into();
+    client.send_envelope(envelope);
 }
 
 pub fn init_sentry(failure_reason: String, dsn: Option<String>) -> Option<ClientInitGuard> {


### PR DESCRIPTION
Replaces capture_event with send_envelope
Will no longer trigger before_send, meaning no logs attached

closes #165 