### PR TITLE
design: moved remote control disabled indicator to the end of title bar

### DIFF
--- a/tauri/src/components/SharingScreen/Controls.tsx
+++ b/tauri/src/components/SharingScreen/Controls.tsx
@@ -14,7 +14,6 @@ type ScreenSharingControlsProps = {
 
 export function ScreenSharingControls({ className }: ScreenSharingControlsProps = {}) {
   const { setIsSharingKeyEvents, setIsSharingMouse } = useSharingContext();
-  const isRemoteControlEnabled = useStore((state) => state.callTokens?.isRemoteControlEnabled);
   const [remoteControlStatus, setRemoteControlStatus] = useState<string>("controlling");
 
   const handleRemoteControlChange = (value: string) => {
@@ -52,21 +51,30 @@ export function ScreenSharingControls({ className }: ScreenSharingControlsProps 
             />
           </div>
         </div>
-        {isRemoteControlEnabled === false && (
-          <div className="absolute right-0">
-            <Tooltip>
-              <TooltipTrigger>
-                <div className="flex flex-row gap-1 items-center muted border border-slate-600 text-white bg-slate-700 px-1.5 py-0.5 rounded-md">
-                  <BiSolidJoystick className="size-4" /> Remote control is disabled
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>
-                <div>Ask the sharer to enable remote control.</div>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        )}
       </div>
+    </TooltipProvider>
+  );
+}
+
+export function RemoteControlDisabledIndicator() {
+  const isRemoteControlEnabled = useStore((state) => state.callTokens?.isRemoteControlEnabled);
+
+  if (isRemoteControlEnabled !== false) {
+    return null;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <div className="flex flex-row gap-1 items-center muted border border-slate-600 text-white bg-slate-700 px-1.5 py-0.5 rounded-md">
+            <BiSolidJoystick className="size-4" /> Remote control is disabled
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <div>Ask the sharer to enable remote control.</div>
+        </TooltipContent>
+      </Tooltip>
     </TooltipProvider>
   );
 }

--- a/tauri/src/windows/screensharing/main.tsx
+++ b/tauri/src/windows/screensharing/main.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { SharingScreen } from "@/components/SharingScreen/SharingScreen";
 import { SharingProvider, useSharingContext } from "./context";
-import { ScreenSharingControls } from "@/components/SharingScreen/Controls";
+import { ScreenSharingControls, RemoteControlDisabledIndicator } from "@/components/SharingScreen/Controls";
 import { Toaster } from "react-hot-toast";
 import { useDisableNativeContextMenu, useResizeListener } from "@/lib/hooks";
 import { cn } from "@/lib/utils";
@@ -199,9 +199,9 @@ function Window() {
       <Toaster position="bottom-center" />
       <div
         data-tauri-drag-region
-        className="title-panel flex items-center h-[40px] px-3 titlebar w-full border-b border-slate-800/20"
+        className="title-panel grid grid-cols-[1fr_auto_1fr] items-center h-[40px] px-3 titlebar w-full border-b border-slate-800/20"
       >
-        <div className="flex items-center gap-2 min-w-[120px]" data-tauri-drag-region="no-drag">
+        <div className="flex items-center justify-start gap-2" data-tauri-drag-region="no-drag">
           <TitlebarButton onClick={handleClose} label="Close window" className="group-hover:bg-red-500">
             <LuX className="size-[10px] stroke-[3px]" />
           </TitlebarButton>
@@ -219,10 +219,12 @@ function Window() {
             : <LuMaximize2 className="size-[10px] stroke-[3px]" />}
           </TitlebarButton>
         </div>
-        <div data-tauri-drag-region="no-drag" className="flex-1 flex justify-center pointer-events-none">
+        <div data-tauri-drag-region="no-drag" className="flex items-center justify-center pointer-events-none">
           <ScreenSharingControls className="pt-0" />
         </div>
-        <div className="min-w-[120px]" aria-hidden="true" />
+        <div className="flex items-center justify-end" data-tauri-drag-region="no-drag">
+          <RemoteControlDisabledIndicator />
+        </div>
       </div>
       <div className="content px-1 pb-0.5 pt-[10px] overflow-hidden">
         {videoToken && <SharingScreen serverURL={livekitUrl} token={videoToken} />}


### PR DESCRIPTION
- Moves remote control disabled indicator to end of title bar
- Moves indicator to its own exported function
- Switches current flexbox implementation with CSS grid (was unable to avoid layout shifting otherwise)

closes #178 