### PR TITLE
improvement(core): give control to sharer when goes out of bounds

### DIFF
--- a/core/src/input/mouse_macos.rs
+++ b/core/src/input/mouse_macos.rs
@@ -118,16 +118,18 @@ impl MouseObserver {
                                 dx -= dx_delta;
                                 dy -= dy_delta;
 
-                                sharer_cursor.set_position(Position {
+                                let sharer_left_monitor = sharer_cursor.set_position(Position {
                                     x: sharer_position.x + dx,
                                     y: sharer_position.y + dy,
                                 });
 
-                                unsafe {
-                                    CGWarpMouseCursorPosition(CGPoint {
-                                        x: location.x,
-                                        y: location.y,
-                                    });
+                                if !sharer_left_monitor {
+                                    unsafe {
+                                        CGWarpMouseCursorPosition(CGPoint {
+                                            x: location.x,
+                                            y: location.y,
+                                        });
+                                    }
                                 }
 
                                 return CallbackResult::Drop;

--- a/core/src/input/mouse_windows.rs
+++ b/core/src/input/mouse_windows.rs
@@ -116,14 +116,18 @@ fn event_processing_thread(
                             let dy = location.y - last_location.y;
 
                             let global_position = sharer_cursor.global_position();
-                            sharer_cursor.set_position(Position {
+                            let sharer_left_monitor = sharer_cursor.set_position(Position {
                                 x: global_position.x + dx,
                                 y: global_position.y + dy,
                             });
 
-                            unsafe {
-                                let _ =
-                                    SetCursorPos(last_location.x as i32, last_location.y as i32);
+                            if !sharer_left_monitor {
+                                unsafe {
+                                    let _ = SetCursorPos(
+                                        last_location.x as i32,
+                                        last_location.y as i32,
+                                    );
+                                }
                             }
                         }
                     } else if event_type == WM_MOUSEWHEEL {

--- a/core/src/overlay_window.rs
+++ b/core/src/overlay_window.rs
@@ -218,12 +218,7 @@ impl OverlayWindow {
         let x = ((x * scale) - self.position.x as f64) / self.extent.width;
         let y = ((y * scale) - self.position.y as f64) / self.extent.height;
 
-        let (checked_x, checked_y) = out_of_bounds(x, y);
-
-        Position {
-            x: checked_x,
-            y: checked_y,
-        }
+        Position { x, y }
     }
 
     /// Converts global coordinates to global display percentage coordinates.
@@ -254,12 +249,7 @@ impl OverlayWindow {
         let y = ((y * scale) - (self.display_info.display_position.y as f64))
             / self.display_info.display_extent.height;
 
-        let (checked_x, checked_y) = out_of_bounds(x, y);
-
-        Position {
-            x: checked_x,
-            y: checked_y,
-        }
+        Position { x, y }
     }
 
     pub fn get_display_scale(&self) -> f64 {
@@ -280,22 +270,4 @@ impl fmt::Display for OverlayWindow {
             self.display_info.display_scale,
         )
     }
-}
-
-fn out_of_bounds(mut x: f64, mut y: f64) -> (f64, f64) {
-    if !(0.0..=1.0).contains(&x) {
-        if x < 0.0 {
-            x = 0.0;
-        } else if x > 1.0 {
-            x = 0.997;
-        }
-    }
-    if !(0.0..=1.0).contains(&y) {
-        if y < 0.0 {
-            y = 0.0;
-        } else if y > 1.0 {
-            y = 0.995;
-        }
-    }
-    (x, y)
 }


### PR DESCRIPTION
Changes the sharer's behaviour to take control back when goes from the sharing display to another one. This is more intuitive than sticking the virtual cursor to the edge of the overlay surface.

We went from this

https://github.com/user-attachments/assets/6c0925b9-e953-4488-9b0b-32f2f47858b9

to this

https://github.com/user-attachments/assets/176471b1-ab51-4467-b975-bb1f0f6026fa

Closes #103 