### PR TITLE
fix(webapp): Fix long teammate names overflowing in webapp

### DIFF
--- a/web-app/src/pages/Dashboard.tsx
+++ b/web-app/src/pages/Dashboard.tsx
@@ -383,14 +383,17 @@ export function Dashboard() {
                     teammates.map((teammate) => (
                       <div
                         key={teammate.id}
-                        className="flex flex-row items-center gap-2 w-fit hover:bg-muted/50 p-2 rounded-lg transition-colors"
+                        className="flex items-center gap-2 w-full hover:bg-muted/50 p-2 rounded-lg transition-colors"
                       >
                         <HoppAvatar
                           src={teammate.avatar_url || undefined}
                           firstName={teammate.first_name}
                           lastName={teammate.last_name}
                         />
-                        <span className="font-medium truncate">
+                        <span
+                          className="font-medium truncate min-w-0"
+                          title={`${teammate.first_name} ${teammate.last_name}`}
+                        >
                           {teammate.first_name} {teammate.last_name.charAt(0)}.
                         </span>
                       </div>


### PR DESCRIPTION
- Prevent long teammate names from overflowing the card.
- Shows full name on hover.

closes #225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated teammate row layout to span full width, improving visual consistency and hover interactions.

* **Accessibility**
  * Enhanced teammate name display with tooltip information and improved text handling for better usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->