### PR TITLE
fix(frontend): race with resize when programmatic resize is happening

### DIFF
--- a/tauri/src/components/SharingScreen/SharingScreen.tsx
+++ b/tauri/src/components/SharingScreen/SharingScreen.tsx
@@ -101,6 +101,7 @@ const ConsumerComponent = React.memo(() => {
     setStreamDimensions,
     rightClickToClear,
     clearDrawingsSignal,
+    isProgrammaticResize,
   } = useSharingContext();
   const isDrawingMode = drawingMode.type !== "Disabled";
   const [wrapperRef, isMouseInside] = useHover();
@@ -175,17 +176,19 @@ const ConsumerComponent = React.memo(() => {
   const throttledResize = useMemo(
     () =>
       throttle(() => {
-        resizeWindow(streamWidth, streamHeight, videoRef);
+        if (!isProgrammaticResize) {
+          resizeWindow(streamWidth, streamHeight, videoRef);
+        }
       }, 250),
-    [streamWidth, streamHeight, videoRef],
+    [streamWidth, streamHeight, videoRef, isProgrammaticResize],
   );
   useResizeListener(throttledResize);
 
   useEffect(() => {
-    if (videoRef.current && track) {
+    if (videoRef.current && track && !isProgrammaticResize) {
       resizeWindow(streamWidth, streamHeight, videoRef);
     }
-  }, [track, streamWidth, streamHeight]);
+  }, [track, streamWidth, streamHeight, isProgrammaticResize]);
 
   useEffect(() => {
     if (track) {

--- a/tauri/src/components/SharingScreen/utils.ts
+++ b/tauri/src/components/SharingScreen/utils.ts
@@ -98,6 +98,7 @@ export async function resizeWindow(streamWidth: number, streamHeight: number, re
       // the only thing we modify is the window height
       new PhysicalSize(Math.floor(newWidth), Math.floor(newHeight)),
     );
+  console.log(`resizeWindow: streamWidth: ${streamWidth}, streamHeight: ${streamHeight}, newWidth: ${newWidth}, newHeight: ${newHeight}`);
   }
 }
 

--- a/tauri/src/windows/screensharing/context.tsx
+++ b/tauri/src/windows/screensharing/context.tsx
@@ -19,6 +19,9 @@ type SharingContextType = {
   // Signal to trigger clearing all drawings - components watch for changes to this value
   clearDrawingsSignal: number;
   triggerClearDrawings: () => void;
+  // Flag to block resizeWindow calls during programmatic resizing
+  isProgrammaticResize: boolean;
+  setIsProgrammaticResize: (value: boolean) => void;
 };
 
 const SharingContext = createContext<SharingContextType | undefined>(undefined);
@@ -44,6 +47,7 @@ export const SharingProvider: React.FC<SharingProviderProps> = ({ children }) =>
   const [streamDimensions, setStreamDimensions] = useState<{ width: number; height: number } | null>(null);
   const [rightClickToClear, setRightClickToClear] = useState<boolean>(false);
   const [clearDrawingsSignal, setClearDrawingsSignal] = useState<number>(0);
+  const [isProgrammaticResize, setIsProgrammaticResize] = useState<boolean>(false);
 
   const triggerClearDrawings = useCallback(() => {
     setClearDrawingsSignal((prev) => prev + 1);
@@ -68,6 +72,8 @@ export const SharingProvider: React.FC<SharingProviderProps> = ({ children }) =>
         setRightClickToClear,
         clearDrawingsSignal,
         triggerClearDrawings,
+        isProgrammaticResize,
+        setIsProgrammaticResize,
       }}
     >
       {children}


### PR DESCRIPTION
Fixes an issue where `resizeWindow` was called during `handleFullscreen` and was resetting the size to the previous value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved window resize handling in screen sharing mode to ensure more stable and consistent behavior during resize operations.
  * Enhanced logging for resize events to support troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->