### PR TITLE
feat: add email field for invoicing

### DIFF
--- a/backend/api-files/openapi.yaml
+++ b/backend/api-files/openapi.yaml
@@ -156,6 +156,23 @@ components:
           type: string
           description: Optional Rewardful referral ID for affiliate tracking
 
+    BillingSettingsRequest:
+      type: object
+      properties:
+        billing_email:
+          type: string
+          format: email
+          description: Email address where invoices will be sent (leave empty to disable invoice emails)
+
+    BillingSettingsResponse:
+      type: object
+      required:
+        - billing_email
+      properties:
+        billing_email:
+          type: string
+          description: Email address where invoices are sent (empty string if not configured)
+
     SessionTokensResponse:
       type: object
       required:
@@ -1179,6 +1196,86 @@ paths:
                 $ref: "#/components/schemas/Error"
         "404":
           description: No subscription found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/auth/billing/settings:
+    get:
+      summary: Get billing settings
+      description: Returns the billing settings for the current user's team, including the billing email where invoices are sent
+      security:
+        - BearerAuth: []
+      responses:
+        "200":
+          description: Billing settings retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BillingSettingsResponse"
+        "400":
+          description: Bad request - user must be part of a team
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Forbidden - only team admins can view billing settings
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    put:
+      summary: Update billing settings
+      description: Updates the billing settings for the current user's team. Set billing_email to configure where invoices are sent, or leave empty to disable invoice emails.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BillingSettingsRequest"
+      responses:
+        "200":
+          description: Billing settings updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BillingSettingsResponse"
+        "400":
+          description: Bad request - invalid email format or user must be part of a team
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "403":
+          description: Forbidden - only team admins can update billing settings
           content:
             application/json:
               schema:

--- a/backend/internal/models/team.go
+++ b/backend/internal/models/team.go
@@ -8,8 +8,9 @@ import (
 
 type Team struct {
 	gorm.Model
-	Name            string `gorm:"not null" json:"name" validate:"required"`
-	IsManualUpgrade bool   `gorm:"default:false" json:"is_manual_upgrade"`
+	Name            string  `gorm:"not null" json:"name" validate:"required"`
+	IsManualUpgrade bool    `gorm:"default:false" json:"is_manual_upgrade"`
+	BillingEmail    *string `gorm:"default:null" json:"billing_email" validate:"omitempty,email"`
 }
 
 func GetTeamByID(db *gorm.DB, id string) (*Team, error) {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -390,6 +390,8 @@ func (s *Server) setupRoutes() {
 	protectedAPI.GET("/billing/subscription", billing.GetSubscriptionStatus)
 	protectedAPI.POST("/billing/create-checkout-session", billing.CreateCheckoutSession)
 	protectedAPI.POST("/billing/create-portal-session", billing.CreatePortalSession)
+	protectedAPI.GET("/billing/settings", billing.GetBillingSettings)
+	protectedAPI.PUT("/billing/settings", billing.UpdateBillingSettings)
 
 	// Debug endpoints - only enabled when ENABLE_DEBUG_ENDPOINTS=true
 	if s.Config.Server.Debug {

--- a/backend/web/emails/hopp-invoice.html
+++ b/backend/web/emails/hopp-invoice.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <link rel="preload" as="image" href="https://dlh49gjxx49i3.cloudfront.net/emails/HoppLogo.png" />
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+  </head>
+  <body
+    style="
+      margin-left: auto;
+      margin-right: auto;
+      margin-top: auto;
+      margin-bottom: auto;
+      background-color: rgb(255, 255, 255);
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
+      font-family:
+        ui-sans-serif, system-ui, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;,
+        &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;;
+    "
+  >
+    <!--$-->
+    <div style="display: none; overflow: hidden; line-height: 1px; opacity: 0; max-height: 0; max-width: 0">
+      Your Hopp invoice #{invoice_number} is ready
+      <div>
+        ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+        ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+        ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+        ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+        ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+        ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+        ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+      </div>
+    </div>
+    <table
+      align="center"
+      width="100%"
+      border="0"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      style="
+        margin-left: auto;
+        margin-right: auto;
+        margin-top: 40px;
+        margin-bottom: 40px;
+        max-width: 465px;
+        border-radius: 0.25rem;
+        border-width: 1px;
+        border-color: rgb(234, 234, 234);
+        border-style: solid;
+        padding: 20px;
+      "
+    >
+      <tbody>
+        <tr style="width: 100%">
+          <td>
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="margin-top: 32px"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <img
+                      alt="Hopp Logo"
+                      height="50"
+                      src="https://dlh49gjxx49i3.cloudfront.net/emails/HoppLogo.png"
+                      style="
+                        margin-left: auto;
+                        margin-right: auto;
+                        margin-top: 0px;
+                        margin-bottom: 0px;
+                        display: block;
+                        outline: none;
+                        border: none;
+                        text-decoration: none;
+                      "
+                      width="auto"
+                    />
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <h1
+              style="
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 30px;
+                margin-bottom: 30px;
+                padding: 0px;
+                text-align: center;
+                font-weight: 400;
+                font-size: 24px;
+                color: rgb(0, 0, 0);
+              "
+            >
+              Invoice #{invoice_number}
+            </h1>
+            <p style="font-size: 14px; color: rgb(0, 0, 0); line-height: 24px; margin-top: 16px; margin-bottom: 16px">
+              Your paid Hopp invoice for period <strong>{period}</strong> is ready to view.
+            </p>
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="margin-top: 24px; margin-bottom: 24px"
+            >
+              <tbody>
+                <tr>
+                  <td align="center">
+                    <a
+                      href="{view_link}"
+                      style="
+                        display: inline-block;
+                        padding: 12px 24px;
+                        font-size: 14px;
+                        font-weight: 600;
+                        color: rgb(255, 255, 255);
+                        text-decoration: none;
+                        border-radius: 6px;
+                        background: radial-gradient(51.67% 88.23% at 50% 125%, #525252 0%, #212121 100%);
+                      "
+                      target="_blank"
+                    >
+                      View Invoice Online
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p
+              style="
+                font-size: 14px;
+                color: rgb(102, 102, 102);
+                line-height: 24px;
+                margin-top: 16px;
+                margin-bottom: 16px;
+                text-align: center;
+              "
+            >
+              Or
+              <a href="{download_link}" target="_blank" style="color: rgb(79, 70, 229); text-decoration: underline"
+                >download the PDF</a
+              >
+            </p>
+            <hr
+              style="
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 26px;
+                margin-bottom: 26px;
+                width: 100%;
+                border-width: 1px;
+                border-color: rgb(234, 234, 234);
+                border-style: solid;
+                border: none;
+                border-top: 1px solid #eaeaea;
+              "
+            />
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="margin-top: 32px; margin-bottom: 32px; text-align: center"
+            >
+              <tbody>
+                <tr>
+                  <td>
+                    <p
+                      style="
+                        color: rgb(102, 102, 102);
+                        font-size: 12px;
+                        line-height: 24px;
+                        margin-top: 16px;
+                        margin-bottom: 16px;
+                      "
+                    >
+                      This invoice was sent automatically from Hopp. If you have any questions, please contact us at
+                      <a href="mailto:costa@gethopp.app" style="color: rgb(79, 70, 229)">costa@gethopp.app</a>
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <!--7--><!--/$-->
+  </body>
+</html>

--- a/tauri/src/openapi.d.ts
+++ b/tauri/src/openapi.d.ts
@@ -1749,6 +1749,144 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/auth/billing/settings": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get billing settings
+     * @description Returns the billing settings for the current user's team, including the billing email where invoices are sent
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Billing settings retrieved successfully */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["BillingSettingsResponse"];
+          };
+        };
+        /** @description Bad request - user must be part of a team */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden - only team admins can view billing settings */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Internal server error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    /**
+     * Update billing settings
+     * @description Updates the billing settings for the current user's team. Set billing_email to configure where invoices are sent, or leave empty to disable invoice emails.
+     */
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["BillingSettingsRequest"];
+        };
+      };
+      responses: {
+        /** @description Billing settings updated successfully */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["BillingSettingsResponse"];
+          };
+        };
+        /** @description Bad request - invalid email format or user must be part of a team */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden - only team admins can update billing settings */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Internal server error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/slack/join/{sessionId}": {
     parameters: {
       query?: never;
@@ -2244,6 +2382,17 @@ export interface components {
       price_id?: string;
       /** @description Optional Rewardful referral ID for affiliate tracking */
       referral?: string;
+    };
+    BillingSettingsRequest: {
+      /**
+       * Format: email
+       * @description Email address where invoices will be sent (leave empty to disable invoice emails)
+       */
+      billing_email?: string;
+    };
+    BillingSettingsResponse: {
+      /** @description Email address where invoices are sent (empty string if not configured) */
+      billing_email: string;
     };
     SessionTokensResponse: {
       /** @description LiveKit token for audio track */

--- a/web-app/src/openapi.d.ts
+++ b/web-app/src/openapi.d.ts
@@ -1749,6 +1749,144 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/auth/billing/settings": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get billing settings
+     * @description Returns the billing settings for the current user's team, including the billing email where invoices are sent
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Billing settings retrieved successfully */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["BillingSettingsResponse"];
+          };
+        };
+        /** @description Bad request - user must be part of a team */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden - only team admins can view billing settings */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Internal server error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    /**
+     * Update billing settings
+     * @description Updates the billing settings for the current user's team. Set billing_email to configure where invoices are sent, or leave empty to disable invoice emails.
+     */
+    put: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["BillingSettingsRequest"];
+        };
+      };
+      responses: {
+        /** @description Billing settings updated successfully */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["BillingSettingsResponse"];
+          };
+        };
+        /** @description Bad request - invalid email format or user must be part of a team */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Forbidden - only team admins can update billing settings */
+        403: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+        /** @description Internal server error */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": components["schemas"]["Error"];
+          };
+        };
+      };
+    };
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/slack/join/{sessionId}": {
     parameters: {
       query?: never;
@@ -2244,6 +2382,17 @@ export interface components {
       price_id?: string;
       /** @description Optional Rewardful referral ID for affiliate tracking */
       referral?: string;
+    };
+    BillingSettingsRequest: {
+      /**
+       * Format: email
+       * @description Email address where invoices will be sent (leave empty to disable invoice emails)
+       */
+      billing_email?: string;
+    };
+    BillingSettingsResponse: {
+      /** @description Email address where invoices are sent (empty string if not configured) */
+      billing_email: string;
     };
     SessionTokensResponse: {
       /** @description LiveKit token for audio track */


### PR DESCRIPTION
Closes #252 

This PR adds explicit functionality to send invoice email. It relies on Stripe's `invoice.payment_succeeded` event. 

How email looks like:
<img width="2412" height="1296" alt="CleanShot 2026-02-04 at 21 41 29@2x" src="https://github.com/user-attachments/assets/8c3c7673-063c-4d28-bd90-e5dadf38a3e4" />

How UI looks like:
<img width="1271" height="780" alt="CleanShot 2026-02-04 at 21 41 55@2x" src="https://github.com/user-attachments/assets/445b1bab-afab-4138-9a9f-62cbac3f1de7" />


To test, first ensure you have a in Stripe Sandbox a current subscription. Then you can use the following to start forwarding webhook calls locally to the server:
```bash
stripe listen --forward-to https://localhost:1926/api/billing/webhook
```

Create a webhook event:
```bash
stripe invoices create --customer cus_<GET ID FROM DB> | jq -r '.id' | xargs -I {} sh -c 'stripe invoices finalize_invoice {} && stripe invoices pay {}'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added billing settings management to configure invoice email addresses
  * Automated invoice payment notifications sent to the configured billing email address
  * New Invoice Settings interface to manage and update billing email preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->