### PR TITLE
improvement: Improve disconnection ux

### DIFF
--- a/tauri/src/components/ui/call-center.tsx
+++ b/tauri/src/components/ui/call-center.tsx
@@ -140,7 +140,7 @@ export function ConnectedActions() {
       room.off(RoomEvent.ParticipantDisconnected, handleParticipantDisconnected);
       room.off(RoomEvent.ParticipantConnected, handleParticipantConnected);
     };
-  }, [room, callParticipant]);
+  }, [room, callParticipant?.id]);
 
   const fetchAccessibilityPermission = async () => {
     const permission = await tauriUtils.getControlPermission();
@@ -770,6 +770,9 @@ function MediaDevicesSettings() {
 
     if (!socketConnected && !callTokens.isReconnecting) {
       updateCallTokens({ isReconnecting: true });
+    } else if (socketConnected && callTokens.isReconnecting && roomState === ConnectionState.Connected) {
+      // Socket recovered and LiveKit is still connected — clear the banner
+      updateCallTokens({ isReconnecting: false });
     }
   }, [socketConnected, callTokens, updateCallTokens, roomState]);
 


### PR DESCRIPTION
* Fires faster the ui indication that a user disconnected. 
* Shows an indication when the remote participant disconnects in a direct call.

closes: https://github.com/gethopp/hopp/issues/208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline wifi-off badge on remote avatars to show when a participant loses connectivity.

* **Bug Fixes**
  * Reconnection now requires both signaling and media links before clearing reconnect state.
  * Media/device reconnection flow improved to wait for signaling before retrying.
  * Increased local track bitrate ceiling for better A/V quality.

* **Style**
  * Centered and tightened layout of the reconnecting status banner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->