### PR TITLE
fix: don't always open main window on dock click

### DIFF
--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1113,12 +1113,18 @@ fn main() {
                 *reopen_requested = true;
             }
 
-            let main_window = app_handle.get_webview_window("main");
-            if let Some(window) = main_window {
+            let screenshare_window = app_handle.get_webview_window("screenshare");
+            if let Some(window) = screenshare_window {
                 let _ = window.show();
                 let _ = window.set_focus();
             } else {
-                log::error!("Main window not found");
+                let main_window = app_handle.get_webview_window("main");
+                if let Some(window) = main_window {
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                } else {
+                    log::error!("Main window not found");
+                }
             }
 
             let reopen_requested_thread = reopen_requested_clone.clone();


### PR DESCRIPTION
When the screen-share window exists, focus on this one and don't open the main window.

Closes #261 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When reopening the app with an active screenshare, the screenshare window is now prioritized and brought to focus instead of the main window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->