### PR TITLE
fix: fix camera setting min fps

### DIFF
--- a/core/src/camera/stream_macos.rs
+++ b/core/src/camera/stream_macos.rs
@@ -82,25 +82,21 @@ unsafe fn set_device_fps(device: &AVCaptureDevice, fps: u32) {
         return;
     }
 
-    let (found, min_fps) = (0..ranges.count()).fold((false, f64::INFINITY), |(found, min), i| {
+    let supported = (0..ranges.count()).any(|i| {
         let range = ranges.objectAtIndex(i);
-        let min_rate = range.minFrameRate();
-        let matches = fps_f64 >= min_rate && fps_f64 <= range.maxFrameRate();
-        (found || matches, min.min(min_rate))
+        fps_f64 >= range.minFrameRate() && fps_f64 <= range.maxFrameRate()
     });
-    let actual_fps = if found {
-        fps_f64
-    } else {
-        log::info!("Camera does not support {fps}fps, using lowest supported {min_fps}fps");
-        min_fps
-    };
+    if !supported {
+        log::info!("Camera does not support {fps}fps, using device default");
+        return;
+    }
 
-    let duration = CMTime::new(1, actual_fps.round() as i32);
+    let duration = CMTime::new(1, fps as i32);
     if device.lockForConfiguration().is_ok() {
         device.setActiveVideoMinFrameDuration(duration);
         device.setActiveVideoMaxFrameDuration(duration);
         device.unlockForConfiguration();
-        log::info!("Camera FPS set to {actual_fps}");
+        log::info!("Camera FPS set to {fps}");
     } else {
         log::warn!("Failed to lock device for FPS configuration");
     }

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
   },
   "productName": "hopp",
   "mainBinaryName": "hopp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "com.hopp.app",
   "plugins": {
     "updater": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS camera frame rate behavior to properly handle unsupported frame rate requests using device defaults.

* **Chores**
  * Version updated to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->