### PR TITLE
fix: improve camera window resource usage

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "hopp_core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -49,7 +49,7 @@ objc2-app-kit = "0.3.1"
 objc2-foundation = "0.3.1"
 objc2-av-foundation = { version = "0.3.1", features = ["AVCaptureDevice", "AVCaptureSession", "AVCaptureOutputBase", "AVCaptureVideoDataOutput", "AVMediaFormat", "AVCaptureInput", "AVCaptureSessionPreset", "objc2-core-media"] }
 objc2-core-video = { version = "0.3.1", features = ["CVBuffer", "CVImageBuffer", "CVPixelBuffer"] }
-objc2-core-media = { version = "0.3.1", features = ["CMSampleBuffer", "CMTime"] }
+objc2-core-media = { version = "0.3.1", features = ["CMSampleBuffer", "CMTime", "CMFormatDescription"] }
 dispatch2 = "0.3.0"
 objc2 = "0.6.1"
 objc2-core-audio = { version = "0.3", features = ["AudioHardware"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopp_core"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Iason Paraskevopoulos <iaswnparaskev@gmail.com>"]
 

--- a/core/src/camera/stream_macos.rs
+++ b/core/src/camera/stream_macos.rs
@@ -82,7 +82,7 @@ pub fn list_devices() -> Vec<socket_lib::CameraDevice> {
 
 fn four_cc(pixel_type: u32) -> String {
     let bytes = pixel_type.to_be_bytes();
-    if bytes.iter().all(|&b| b >= 0x20 && b < 0x7f) {
+    if bytes.iter().all(|&b| (0x20..0x7f).contains(&b)) {
         format!("'{}'", std::str::from_utf8(&bytes).unwrap_or("????"))
     } else {
         format!("0x{pixel_type:08X}")

--- a/core/src/camera/stream_macos.rs
+++ b/core/src/camera/stream_macos.rs
@@ -413,6 +413,7 @@ impl CameraStream {
 
             let output = AVCaptureVideoDataOutput::new();
             output.setAlwaysDiscardsLateVideoFrames(true);
+            // TODO: we should choose the active format based on the resolution.
 
             if !session.canAddOutput(&output) {
                 return Err("Cannot add camera output to session".to_string());

--- a/core/src/camera/stream_macos.rs
+++ b/core/src/camera/stream_macos.rs
@@ -1,6 +1,6 @@
 use super::{CameraStreamConfig, CameraStreamMessage};
-use crate::livekit::video::VideoBufferManager;
 use crate::utils::geometry::aspect_fit;
+use crate::{camera::stream::CAMERA_STREAM_FPS_HIGH, livekit::video::VideoBufferManager};
 use livekit::webrtc::{
     prelude::VideoBuffer,
     video_frame::{I420Buffer, VideoFrame, VideoRotation},
@@ -20,11 +20,12 @@ use objc2_av_foundation::{
     AVCaptureConnection, AVCaptureDevice, AVCaptureDeviceDiscoverySession, AVCaptureDeviceInput,
     AVCaptureDevicePosition, AVCaptureDeviceTypeBuiltInWideAngleCamera,
     AVCaptureDeviceTypeExternal, AVCaptureOutput, AVCaptureSession, AVCaptureVideoDataOutput,
-    AVCaptureVideoDataOutputSampleBufferDelegate, AVMediaTypeVideo,
+    AVCaptureVideoDataOutputSampleBufferDelegate, AVFrameRateRange, AVMediaTypeVideo,
 };
-use objc2_core_media::{CMSampleBuffer, CMTime};
+use objc2_core_media::{CMSampleBuffer, CMTime, CMTimeFlags};
 use objc2_core_video::{
-    kCVPixelFormatType_32BGRA, kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+    kCVPixelBufferPixelFormatTypeKey, kCVPixelFormatType_32BGRA,
+    kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
     kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange, kCVPixelFormatType_422YpCbCr8,
     kCVPixelFormatType_422YpCbCr8_yuvs, kCVReturnSuccess, CVPixelBufferGetBaseAddress,
     CVPixelBufferGetBaseAddressOfPlane, CVPixelBufferGetBytesPerRow,
@@ -32,7 +33,15 @@ use objc2_core_video::{
     CVPixelBufferGetWidth, CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags,
     CVPixelBufferUnlockBaseAddress,
 };
-use objc2_foundation::{NSArray, NSObject, NSString};
+use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSObject, NSString};
+
+const SUPPORTED_PIXEL_FORMATS: &[u32] = &[
+    kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+    kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+    kCVPixelFormatType_32BGRA,
+    kCVPixelFormatType_422YpCbCr8_yuvs,
+    kCVPixelFormatType_422YpCbCr8,
+];
 
 fn discover_video_devices() -> Retained<NSArray<AVCaptureDevice>> {
     unsafe {
@@ -71,44 +80,54 @@ pub fn list_devices() -> Vec<socket_lib::CameraDevice> {
     }
 }
 
-/// Set FPS on device hardware. If target fps is outside supported ranges, uses the lowest supported fps.
-unsafe fn set_device_fps(device: &AVCaptureDevice, fps: u32) {
-    let fps_f64 = fps as f64;
-    let format = device.activeFormat();
-    let ranges = format.videoSupportedFrameRateRanges();
-
-    if ranges.count() == 0 {
-        log::warn!("Camera has no supported frame rate ranges, skipping FPS configuration");
-        return;
-    }
-
-    let supported = (0..ranges.count()).any(|i| {
-        let range = ranges.objectAtIndex(i);
-        fps_f64 >= range.minFrameRate() && fps_f64 <= range.maxFrameRate()
-    });
-    if !supported {
-        log::info!("Camera does not support {fps}fps, using device default");
-        return;
-    }
-
-    let duration = CMTime::new(1, fps as i32);
-    if device.lockForConfiguration().is_ok() {
-        device.setActiveVideoMinFrameDuration(duration);
-        device.setActiveVideoMaxFrameDuration(duration);
-        device.unlockForConfiguration();
-        log::info!("Camera FPS set to {fps}");
+fn four_cc(pixel_type: u32) -> String {
+    let bytes = pixel_type.to_be_bytes();
+    if bytes.iter().all(|&b| b >= 0x20 && b < 0x7f) {
+        format!("'{}'", std::str::from_utf8(&bytes).unwrap_or("????"))
     } else {
-        log::warn!("Failed to lock device for FPS configuration");
+        format!("0x{pixel_type:08X}")
+    }
+}
+
+fn clamp_fps_to_supported_ranges(
+    ranges: &NSArray<AVFrameRateRange>,
+    target_fps: f64,
+) -> Option<f64> {
+    let count = ranges.count();
+    if count == 0 {
+        return None;
+    }
+
+    unsafe {
+        for i in 0..count {
+            let range = ranges.objectAtIndex(i);
+            if target_fps >= range.minFrameRate() && target_fps <= range.maxFrameRate() {
+                return Some(target_fps);
+            }
+        }
+
+        let mut best_fps = None;
+        let mut best_distance = f64::MAX;
+        for i in 0..count {
+            let range = ranges.objectAtIndex(i);
+            for boundary in [range.minFrameRate(), range.maxFrameRate()] {
+                let distance = (boundary - target_fps).abs();
+                if distance < best_distance {
+                    best_distance = distance;
+                    best_fps = Some(boundary);
+                }
+            }
+        }
+        best_fps
     }
 }
 
 struct CameraDelegateState {
-    device: Retained<AVCaptureDevice>,
     buffer_source: NativeVideoSource,
     video_buffer_manager: Arc<VideoBufferManager>,
     config: Arc<CameraStreamConfig>,
     capture_start: Instant,
-    current_fps: u32,
+    last_frame_time: Instant,
     i420: Option<I420Buffer>,
     stream_frame: Option<VideoFrame<I420Buffer>>,
     prev_stream_w: u32,
@@ -137,11 +156,13 @@ define_class!(
                 None => return,
             };
 
-            let cur_fps = state.config.target_fps();
-            if cur_fps != state.current_fps {
-                unsafe { set_device_fps(&state.device, cur_fps) };
-                state.current_fps = cur_fps;
+            let target_fps = state.config.target_fps();
+            let min_interval = std::time::Duration::from_micros(1_000_000 / target_fps as u64);
+            let now = Instant::now();
+            if now.duration_since(state.last_frame_time) < min_interval {
+                return;
             }
+            state.last_frame_time = now;
 
             unsafe {
                 let image_buffer = sample_buffer.image_buffer();
@@ -392,25 +413,59 @@ impl CameraStream {
 
             let output = AVCaptureVideoDataOutput::new();
             output.setAlwaysDiscardsLateVideoFrames(true);
-            output.setVideoSettings(None);
 
             if !session.canAddOutput(&output) {
                 return Err("Cannot add camera output to session".to_string());
             }
             session.addOutput(&output);
 
-            let initial_fps = config.target_fps();
-            set_device_fps(&device, initial_fps);
+            // Set hardware frame rate to avoid excess callbacks from the camera.
+            let target_fps = CAMERA_STREAM_FPS_HIGH as f64;
+            let active_format = device.activeFormat();
+            let frame_rate_ranges = active_format.videoSupportedFrameRateRanges();
+            if let Some(clamped_fps) = clamp_fps_to_supported_ranges(&frame_rate_ranges, target_fps)
+            {
+                if let Ok(()) = device.lockForConfiguration() {
+                    let frame_duration = CMTime {
+                        value: 1,
+                        timescale: clamped_fps as i32,
+                        flags: CMTimeFlags::Valid,
+                        epoch: 0,
+                    };
+                    device.setActiveVideoMinFrameDuration(frame_duration);
+                    device.setActiveVideoMaxFrameDuration(frame_duration);
+                    device.unlockForConfiguration();
+                    log::info!(
+                        "Camera frame rate set to {} fps (requested {})",
+                        clamped_fps,
+                        target_fps
+                    );
+                }
+            }
+
+            // Request first supported pixel format from device's available list.
+            let available_formats = output.availableVideoCVPixelFormatTypes();
+            let chosen_format = SUPPORTED_PIXEL_FORMATS.iter().find(|&&fmt| {
+                (0..available_formats.count())
+                    .any(|i| available_formats.objectAtIndex(i).as_u32() == fmt)
+            });
+            let Some(&format) = chosen_format else {
+                return Err("Camera does not support any required pixel format".to_string());
+            };
+            log::info!("Camera requesting pixel format: {}", four_cc(format));
+            let format_number = NSNumber::new_u32(format);
+            let format_anyobj = format_number.into_super().into_super().into_super();
+            let key: &NSString =
+                &*(kCVPixelBufferPixelFormatTypeKey as *const _ as *const NSString);
+            let settings = NSDictionary::from_retained_objects(&[key], &[format_anyobj]);
+            output.setVideoSettings(Some(&settings));
 
             let state = CameraDelegateState {
-                device: device.clone(),
                 buffer_source: buffer_source.clone(),
                 video_buffer_manager: video_buffer_manager.clone(),
                 config: config.clone(),
                 capture_start: Instant::now(),
-                // Use 0 as sentinel so first frame always re-applies FPS after session starts,
-                // since set_device_fps above runs before startRunning() and may have no effect.
-                current_fps: 0,
+                last_frame_time: Instant::now(),
                 i420: None,
                 stream_frame: None,
                 prev_stream_w: 0,

--- a/core/src/graphics/yuv_renderer.rs
+++ b/core/src/graphics/yuv_renderer.rs
@@ -297,7 +297,7 @@ impl YuvPipeline {
         state.y_staging_buf[buf_idx]
             .slice(..)
             .map_async(wgpu::MapMode::Write, |_| {});
-        device.poll(wgpu::PollType::Poll).ok();
+        device.poll(wgpu::PollType::wait_indefinitely()).ok();
         {
             let mut view = state.y_staging_buf[buf_idx]
                 .slice(..)
@@ -310,7 +310,7 @@ impl YuvPipeline {
         state.u_staging_buf[buf_idx]
             .slice(..)
             .map_async(wgpu::MapMode::Write, |_| {});
-        device.poll(wgpu::PollType::Poll).ok();
+        device.poll(wgpu::PollType::wait_indefinitely()).ok();
         {
             let mut view = state.u_staging_buf[buf_idx]
                 .slice(..)
@@ -323,7 +323,7 @@ impl YuvPipeline {
         state.v_staging_buf[buf_idx]
             .slice(..)
             .map_async(wgpu::MapMode::Write, |_| {});
-        device.poll(wgpu::PollType::Poll).ok();
+        device.poll(wgpu::PollType::wait_indefinitely()).ok();
         {
             let mut view = state.v_staging_buf[buf_idx]
                 .slice(..)

--- a/core/src/graphics/yuv_renderer.rs
+++ b/core/src/graphics/yuv_renderer.rs
@@ -49,6 +49,10 @@ struct ParticipantGpuState {
     bind_group: wgpu::BindGroup,
     params_buf: wgpu::Buffer,
     dims: (u32, u32),
+    y_staging_buf: [wgpu::Buffer; 2],
+    u_staging_buf: [wgpu::Buffer; 2],
+    v_staging_buf: [wgpu::Buffer; 2],
+    active_buffer: usize,
 }
 
 // ── Pipeline (shared GPU state) ─────────────────────────────────────────────
@@ -200,6 +204,51 @@ impl YuvPipeline {
                 ],
             });
 
+            let y_staging_buf = [
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("YUV Y staging buffer 0"),
+                    size: (y_tex_w * height) as u64,
+                    usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
+                    mapped_at_creation: false,
+                }),
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("YUV Y staging buffer 1"),
+                    size: (y_tex_w * height) as u64,
+                    usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
+                    mapped_at_creation: false,
+                }),
+            ];
+
+            let u_staging_buf = [
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("YUV U staging buffer 0"),
+                    size: (uv_tex_w * (height / 2)) as u64,
+                    usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
+                    mapped_at_creation: false,
+                }),
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("YUV U staging buffer 1"),
+                    size: (uv_tex_w * (height / 2)) as u64,
+                    usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
+                    mapped_at_creation: false,
+                }),
+            ];
+
+            let v_staging_buf = [
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("YUV V staging buffer 0"),
+                    size: (uv_tex_w * (height / 2)) as u64,
+                    usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
+                    mapped_at_creation: false,
+                }),
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("YUV V staging buffer 1"),
+                    size: (uv_tex_w * (height / 2)) as u64,
+                    usage: wgpu::BufferUsages::MAP_WRITE | wgpu::BufferUsages::COPY_SRC,
+                    mapped_at_creation: false,
+                }),
+            ];
+
             self.participants.insert(
                 participant_id,
                 ParticipantGpuState {
@@ -209,6 +258,10 @@ impl YuvPipeline {
                     bind_group,
                     params_buf,
                     dims: (width, height),
+                    y_staging_buf,
+                    u_staging_buf,
+                    v_staging_buf,
+                    active_buffer: 0,
                 },
             );
         }
@@ -217,7 +270,7 @@ impl YuvPipeline {
     }
 
     /// Upload YUV plane data to GPU textures for the given participant.
-    /// Accepts raw slices and dimensions directly to avoid intermediate copies.
+    /// Uses double-buffered staging buffers to avoid per-frame allocation.
     fn upload_yuv(
         &mut self,
         participant_id: u64,
@@ -236,20 +289,68 @@ impl YuvPipeline {
         let uv_tex_w = align_to(frame.width / 2, 256);
         let uv_h = frame.height / 2;
 
-        // Data is already padded to GPU-aligned strides in VideoBuffer,
-        // upload directly — no intermediate copy needed.
-        queue.write_texture(
+        // Toggle active buffer for next frame
+        let buf_idx = state.active_buffer;
+        state.active_buffer = 1 - buf_idx;
+
+        // --- Y plane ---
+        state.y_staging_buf[buf_idx]
+            .slice(..)
+            .map_async(wgpu::MapMode::Write, |_| {});
+        device.poll(wgpu::PollType::Poll).ok();
+        {
+            let mut view = state.y_staging_buf[buf_idx]
+                .slice(..)
+                .get_mapped_range_mut();
+            view[..frame.y.len()].copy_from_slice(frame.y);
+        }
+        state.y_staging_buf[buf_idx].unmap();
+
+        // --- U plane ---
+        state.u_staging_buf[buf_idx]
+            .slice(..)
+            .map_async(wgpu::MapMode::Write, |_| {});
+        device.poll(wgpu::PollType::Poll).ok();
+        {
+            let mut view = state.u_staging_buf[buf_idx]
+                .slice(..)
+                .get_mapped_range_mut();
+            view[..frame.u.len()].copy_from_slice(frame.u);
+        }
+        state.u_staging_buf[buf_idx].unmap();
+
+        // --- V plane ---
+        state.v_staging_buf[buf_idx]
+            .slice(..)
+            .map_async(wgpu::MapMode::Write, |_| {});
+        device.poll(wgpu::PollType::Poll).ok();
+        {
+            let mut view = state.v_staging_buf[buf_idx]
+                .slice(..)
+                .get_mapped_range_mut();
+            view[..frame.v.len()].copy_from_slice(frame.v);
+        }
+        state.v_staging_buf[buf_idx].unmap();
+
+        // --- Single command encoder for all 3 planes ---
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("YUV upload encoder"),
+        });
+
+        encoder.copy_buffer_to_texture(
+            wgpu::TexelCopyBufferInfo {
+                buffer: &state.y_staging_buf[buf_idx],
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(y_tex_w),
+                    rows_per_image: Some(frame.height),
+                },
+            },
             wgpu::TexelCopyTextureInfo {
                 texture: &state.y_tex,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
-            },
-            frame.y,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(y_tex_w),
-                rows_per_image: Some(frame.height),
             },
             wgpu::Extent3d {
                 width: y_tex_w,
@@ -258,18 +359,20 @@ impl YuvPipeline {
             },
         );
 
-        queue.write_texture(
+        encoder.copy_buffer_to_texture(
+            wgpu::TexelCopyBufferInfo {
+                buffer: &state.u_staging_buf[buf_idx],
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(uv_tex_w),
+                    rows_per_image: Some(uv_h),
+                },
+            },
             wgpu::TexelCopyTextureInfo {
                 texture: &state.u_tex,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
-            },
-            frame.u,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(uv_tex_w),
-                rows_per_image: Some(uv_h),
             },
             wgpu::Extent3d {
                 width: uv_tex_w,
@@ -278,18 +381,20 @@ impl YuvPipeline {
             },
         );
 
-        queue.write_texture(
+        encoder.copy_buffer_to_texture(
+            wgpu::TexelCopyBufferInfo {
+                buffer: &state.v_staging_buf[buf_idx],
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(uv_tex_w),
+                    rows_per_image: Some(uv_h),
+                },
+            },
             wgpu::TexelCopyTextureInfo {
                 texture: &state.v_tex,
                 mip_level: 0,
                 origin: wgpu::Origin3d::ZERO,
                 aspect: wgpu::TextureAspect::All,
-            },
-            frame.v,
-            wgpu::TexelCopyBufferLayout {
-                offset: 0,
-                bytes_per_row: Some(uv_tex_w),
-                rows_per_image: Some(uv_h),
             },
             wgpu::Extent3d {
                 width: uv_tex_w,
@@ -297,6 +402,8 @@ impl YuvPipeline {
                 depth_or_array_layers: 1,
             },
         );
+
+        queue.submit(Some(encoder.finish()));
 
         // Update params uniform.
         // In stretch-to-fill mode, force aspect terms to match the source aspect so

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -346,7 +346,7 @@ impl<'a> Application<'a> {
             window_manager: None,
             audio_capturer,
             audio_player,
-            noise_cancellation_enabled: Arc::new(AtomicBool::new(false)),
+            noise_cancellation_enabled: Arc::new(AtomicBool::new(true)),
             camera_capturer: camera_capturer.clone(),
             _camera_capturer_events: Some(std::thread::spawn(move || {
                 poll_camera_stream(camera_capturer_clone)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -243,6 +243,7 @@ pub struct Application<'a> {
     camera_window: Option<CameraWindow>,
     screensharing_window: Option<ScreensharingWindow>,
     screensharing_redraw_thread: Option<JoinHandle<()>>,
+    camera_redraw_thread: Option<JoinHandle<()>>,
     stats_window: Option<StatsWindow>,
     hang_protection_counter: Arc<AtomicU64>,
 }
@@ -345,7 +346,7 @@ impl<'a> Application<'a> {
             window_manager: None,
             audio_capturer,
             audio_player,
-            noise_cancellation_enabled: Arc::new(AtomicBool::new(true)),
+            noise_cancellation_enabled: Arc::new(AtomicBool::new(false)),
             camera_capturer: camera_capturer.clone(),
             _camera_capturer_events: Some(std::thread::spawn(move || {
                 poll_camera_stream(camera_capturer_clone)
@@ -355,6 +356,7 @@ impl<'a> Application<'a> {
             camera_window: None,
             screensharing_window: None,
             screensharing_redraw_thread: None,
+            camera_redraw_thread: None,
             stats_window: None,
             hang_protection_counter,
         })
@@ -557,6 +559,19 @@ impl<'a> Application<'a> {
     fn join_screensharing_redraw_thread(&mut self) {
         if let Some(handle) = self.screensharing_redraw_thread.take() {
             let _ = handle.join();
+        }
+    }
+
+    fn join_camera_redraw_thread(&mut self) {
+        if let Some(handle) = self.camera_redraw_thread.take() {
+            let _ = handle.join();
+        }
+    }
+
+    fn close_camera_window(&mut self) {
+        log::info!("close_camera_window");
+        if let Some(mut cam) = self.camera_window.take() {
+            self.camera_redraw_thread = cam.take_redraw_thread();
         }
     }
 
@@ -1014,7 +1029,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     room_service.destroy_room();
                 }
 
-                self.camera_window = None;
+                self.close_camera_window();
                 self.close_screensharing_window();
                 self.stats_window = None;
 
@@ -1429,6 +1444,9 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                 }
             }
             UserEvent::StartCamera { msg, from_socket } => {
+                if self.camera_window.is_none() {
+                    self.join_camera_redraw_thread();
+                }
                 let device_name = if msg.device_name.is_some() {
                     msg.device_name
                 } else if let Err(e) = self.socket.send(Message::QueryPreferredCamera) {
@@ -1566,7 +1584,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                         guard.values().any(|info| info.camera_active())
                     };
                     if !any_active {
-                        self.camera_window = None;
+                        self.close_camera_window();
                     }
                 }
             }
@@ -1576,6 +1594,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     log::info!("user_event: Camera window already exists, skipping");
                     return;
                 }
+                self.join_camera_redraw_thread();
                 if let Some(room_service) = self.room_service.as_ref() {
                     let participants = room_service.participants();
                     match CameraWindow::new(
@@ -1661,7 +1680,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
             }
             UserEvent::CloseCameraWindow => {
                 log::info!("user_event: CloseCameraWindow");
-                self.camera_window = None;
+                self.close_camera_window();
             }
             UserEvent::BringWindowsToFront => {
                 log::info!("user_event: BringWindowsToFront");
@@ -2179,15 +2198,6 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
 
         let now = std::time::Instant::now();
         let mut next_redraw: Option<std::time::Instant> = None;
-
-        // Handle camera window
-        if let Some(camera) = &self.camera_window {
-            let camera_next = camera.next_redraw_at();
-            if now >= camera_next {
-                camera.request_redraw();
-            }
-            next_redraw = Some(camera_next);
-        }
 
         // Handle stats window
         if let Some(stats_win) = &mut self.stats_window {

--- a/core/src/room_service.rs
+++ b/core/src/room_service.rs
@@ -800,6 +800,8 @@ async fn room_service_commands(
 ) {
     let mut stats_task: Option<tokio::task::JoinHandle<()>> = None;
     let mut audio_publisher: Option<AudioPublisher> = None;
+    let mut last_cursor_publish = Instant::now();
+    const CURSOR_THROTTLE: Duration = Duration::from_millis(16);
 
     while let Some(command) = service_rx.recv().await {
         log::debug!("room_service_commands: Received command {command:?}");
@@ -1176,6 +1178,11 @@ async fn room_service_commands(
                 inner.clear().await;
             }
             RoomServiceCommand::PublishCursorPosition(x, y, _pointer) => {
+                let now = Instant::now();
+                if now.duration_since(last_cursor_publish) < CURSOR_THROTTLE {
+                    continue;
+                }
+                last_cursor_publish = now;
                 let inner_room = inner.room.lock().await;
                 if inner_room.is_none() {
                     log::warn!("room_service_commands: Room doesn't exist");

--- a/core/src/room_service.rs
+++ b/core/src/room_service.rs
@@ -801,7 +801,7 @@ async fn room_service_commands(
     let mut stats_task: Option<tokio::task::JoinHandle<()>> = None;
     let mut audio_publisher: Option<AudioPublisher> = None;
     let mut last_cursor_publish = Instant::now();
-    const CURSOR_THROTTLE: Duration = Duration::from_millis(16);
+    const CURSOR_THROTTLE: Duration = Duration::from_millis(10);
 
     while let Some(command) = service_rx.recv().await {
         log::debug!("room_service_commands: Received command {command:?}");
@@ -881,7 +881,7 @@ async fn room_service_commands(
                             LocalTrack::Video(camera_track.clone()),
                             TrackPublishOptions {
                                 source: TrackSource::Camera,
-                                video_codec: VideoCodec::VP9,
+                                video_codec: VideoCodec::H264,
                                 simulcast: false,
                                 video_encoding: Some(VideoEncoding {
                                     max_bitrate: CAMERA_MAX_BITRATE,

--- a/core/src/window/camera_window.rs
+++ b/core/src/window/camera_window.rs
@@ -13,7 +13,8 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant as StdInstant};
+use std::thread::JoinHandle;
+use std::time::Duration;
 
 use iced::widget::{
     button, column, container, mouse_area, row, shader, stack, svg, text, tooltip, Space,
@@ -59,8 +60,26 @@ const CAMERA_WINDOW_HEIGHT: f64 = 555.0;
 const CAMERA_WINDOW_MIN_WIDTH: f64 = 100.0;
 const CAMERA_WINDOW_MIN_HEIGHT: f64 = 100.0;
 
+use std::sync::mpsc;
+
 /// Target redraw interval: 30 FPS
 const REDRAW_INTERVAL: Duration = Duration::from_millis(1_000 / 30);
+
+pub enum RedrawCommand {
+    Stop,
+}
+
+fn spawn_redraw_thread(
+    redraw_rx: mpsc::Receiver<RedrawCommand>,
+    window: Arc<Window>,
+) -> JoinHandle<()> {
+    std::thread::spawn(move || loop {
+        match redraw_rx.recv_timeout(REDRAW_INTERVAL) {
+            Ok(RedrawCommand::Stop) | Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(mpsc::RecvTimeoutError::Timeout) => window.request_redraw(),
+        }
+    })
+}
 
 const CONTENT_PADDING: f32 = 12.0;
 
@@ -180,9 +199,10 @@ pub struct CameraWindow {
     cursor: mouse::Cursor,
     modifiers: ModifiersState,
     state: CameraState,
-    last_redraw: StdInstant,
     participants: Arc<RwLock<HashMap<String, ParticipantInfo>>>,
     event_loop_proxy: EventLoopProxy<UserEvent>,
+    redraw_tx: mpsc::Sender<RedrawCommand>,
+    redraw_thread: Option<JoinHandle<()>>,
 }
 
 pub fn camera_window_attributes() -> WindowAttributes {
@@ -286,8 +306,11 @@ impl CameraWindow {
             ..Default::default()
         };
 
+        let (redraw_tx, redraw_rx) = mpsc::channel();
+        let redraw_thread = Some(spawn_redraw_thread(redraw_rx, window.clone()));
+
         Ok(Self {
-            window,
+            window: window.clone(),
             surface,
             device,
             format,
@@ -299,9 +322,10 @@ impl CameraWindow {
             cursor: mouse::Cursor::Unavailable,
             modifiers: ModifiersState::default(),
             state,
-            last_redraw: StdInstant::now(),
             participants,
             event_loop_proxy,
+            redraw_tx,
+            redraw_thread,
         })
     }
 
@@ -316,13 +340,16 @@ impl CameraWindow {
     }
 
     /// Request a redraw of the camera window.
-    pub fn request_redraw(&self) {
+    pub fn request_redraw(&mut self) {
         self.window.request_redraw();
     }
 
-    /// Returns the instant when the next redraw should occur.
-    pub fn next_redraw_at(&self) -> StdInstant {
-        self.last_redraw + REDRAW_INTERVAL
+    /// Take ownership of the redraw thread handle for later joining.
+    pub fn take_redraw_thread(&mut self) -> Option<JoinHandle<()>> {
+        if let Err(e) = self.redraw_tx.send(RedrawCommand::Stop) {
+            log::error!("CameraWindow::take_redraw_thread: failed to send Stop: {e:?}");
+        }
+        self.redraw_thread.take()
     }
 
     /// Update the local camera active state. Call from StartCamera/StopCamera handlers.
@@ -427,17 +454,11 @@ impl CameraWindow {
                         },
                     );
 
-                    self.window.request_redraw();
+                    self.request_redraw();
                 }
             }
             WindowEvent::RedrawRequested => {
-                if self.last_redraw.elapsed() >= REDRAW_INTERVAL {
-                    self.redraw();
-                    self.last_redraw = StdInstant::now();
-                }
-                // Don't call window.request_redraw() here — it wakes the event loop
-                // immediately, creating a busy-loop. Frame scheduling is handled
-                // by Application::about_to_wait() via ControlFlow::WaitUntil.
+                self.redraw();
             }
             WindowEvent::CloseRequested => {
                 self.window.set_visible(false);
@@ -870,7 +891,6 @@ impl CameraWindow {
             },
             self.cursor,
         );
-
         self.cache = Some(interface.into_cache());
 
         // Present via wgpu
@@ -887,6 +907,12 @@ impl CameraWindow {
 
         self.window.pre_present_notify();
         output.present();
+    }
+}
+
+impl Drop for CameraWindow {
+    fn drop(&mut self) {
+        let _ = self.redraw_thread.take();
     }
 }
 

--- a/core/src/window/screensharing_window.rs
+++ b/core/src/window/screensharing_window.rs
@@ -2027,7 +2027,6 @@ impl ScreensharingWindow {
                 return Vec::new();
             }
         }
-
         let output = match self.surface.get_current_texture() {
             Ok(output) => output,
             Err(e) => {
@@ -2078,7 +2077,6 @@ impl ScreensharingWindow {
             },
             self.cursor,
         );
-
         self.cache = Some(interface.into_cache());
 
         // Present via wgpu
@@ -2107,6 +2105,7 @@ impl ScreensharingWindow {
         if !skip_buffer {
             self.last_rendered_frame_id = current_frame_id;
         }
+
         cleared
     }
 }

--- a/tauri/src-tauri/tauri.conf.json
+++ b/tauri/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
   },
   "productName": "hopp",
   "mainBinaryName": "hopp",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "com.hopp.app",
   "plugins": {
     "updater": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved camera stream timing and selected pixel format on macOS for more stable frame delivery
  * Camera window redraws moved to a background thread for smoother UI updates
  * More efficient video frame uploads for reduced rendering overhead
  * Cursor position updates are now rate-limited to reduce update chatter

* **Default Behavior**
  * Local camera track publishing now uses H.264 codec by default

* **Chores**
  * App and core package versions bumped for this release
<!-- end of auto-generated comment: release notes by coderabbit.ai -->