### PR TITLE
improvement: standalone window for sharer drawing

### DIFF
--- a/core/socket_lib/src/lib.rs
+++ b/core/socket_lib/src/lib.rs
@@ -235,6 +235,7 @@ pub enum Message {
     LastModeChanged(StoredMode),
     ActiveMicChanged(String),
     ActiveCameraChanged(String),
+    DrawingDisabled,
     SetNoiseCancellation(bool),
     /// Microphone RMS level in [0.0, 1.0], emitted ~1 Hz from core capturer.
     MicrophoneAudioLevel(f32),

--- a/core/socket_lib/src/lib.rs
+++ b/core/socket_lib/src/lib.rs
@@ -231,6 +231,7 @@ pub enum Message {
     RoomConnectionFailed(String),
     OpenContentPicker,
     ControllerDrawPersistChanged(bool),
+    SharerDrawPersistChanged(bool),
     LastModeChanged(StoredMode),
     ActiveMicChanged(String),
     ActiveCameraChanged(String),

--- a/core/src/graphics/draw.rs
+++ b/core/src/graphics/draw.rs
@@ -185,12 +185,11 @@ impl Draw {
         translate: &dyn Fn(Position) -> Position,
     ) -> Geometry {
         self.completed_cache.draw(renderer, bounds.size(), |frame| {
-            let glow_stroke = self.make_glow_stroke();
+            let outline_stroke = self.make_outline_stroke();
             let core_stroke = self.make_stroke();
             for draw_path in &self.completed_paths {
                 if let Some(path) = Self::build_path(&draw_path.points, translate) {
-                    // Two-pass rendering: glow first (wider, semi-transparent), then core
-                    frame.stroke(&path, glow_stroke);
+                    frame.stroke(&path, outline_stroke);
                     frame.stroke(&path, core_stroke);
                 }
             }
@@ -205,8 +204,7 @@ impl Draw {
     ) {
         if let Some(in_progress) = &self.in_progress_path {
             if let Some(path) = Self::build_path(&in_progress.points, translate) {
-                // Two-pass rendering: glow first (wider, semi-transparent), then core
-                frame.stroke(&path, self.make_glow_stroke());
+                frame.stroke(&path, self.make_outline_stroke());
                 frame.stroke(&path, self.make_stroke());
             }
         }
@@ -222,12 +220,12 @@ impl Draw {
         }
     }
 
-    fn make_glow_stroke(&self) -> Stroke<'static> {
-        let mut glow_color = self.color;
-        glow_color.a *= 0.60;
+    fn make_outline_stroke(&self) -> Stroke<'static> {
+        let mut outline_color = self.color;
+        outline_color.a *= 0.25;
         Stroke {
-            style: stroke::Style::Solid(glow_color),
-            width: 3.0 + 1.5,
+            style: stroke::Style::Solid(outline_color),
+            width: 3.0 + 0.75,
             line_cap: stroke::LineCap::Round,
             line_join: stroke::LineJoin::Round,
             line_dash: stroke::LineDash::default(),

--- a/core/src/graphics/graphics_window_context.rs
+++ b/core/src/graphics/graphics_window_context.rs
@@ -205,6 +205,7 @@ pub struct ContextManager {
     pub camera_context: GraphicsWindowContext,
     pub screensharing_context: GraphicsWindowContext,
     pub overlay_context: GraphicsWindowContext,
+    pub drawing_context: GraphicsWindowContext,
 }
 
 impl ContextManager {
@@ -257,10 +258,25 @@ impl ContextManager {
             SurfaceInitProfile::Overlay,
         )?;
 
+        let drawing_attrs =
+            crate::window::drawing_window::drawing_window_attributes().with_visible(false);
+        let drawing_window = Arc::new(event_loop.create_window(drawing_attrs).map_err(|e| {
+            log::error!("ContextManager: failed to create dummy drawing window: {e:?}");
+            GraphicsWindowContextError::SurfaceCreation
+        })?);
+        let (drawing_context, _) = GraphicsWindowContext::new(
+            &drawing_window,
+            wgpu::PowerPreference::HighPerformance,
+            wgpu::PresentMode::AutoVsync,
+            "DrawingWindow",
+            SurfaceInitProfile::Overlay,
+        )?;
+
         Ok(Self {
             camera_context,
             screensharing_context,
             overlay_context,
+            drawing_context,
         })
     }
 
@@ -283,5 +299,12 @@ impl ContextManager {
         window: &Arc<Window>,
     ) -> Result<SurfaceInfo, GraphicsWindowContextError> {
         self.overlay_context.create_surface(window)
+    }
+
+    pub fn create_drawing_surface(
+        &self,
+        window: &Arc<Window>,
+    ) -> Result<SurfaceInfo, GraphicsWindowContextError> {
+        self.drawing_context.create_surface(window)
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -47,6 +47,8 @@ pub mod utils {
 pub(crate) mod window {
     pub(crate) mod aspect_ratio;
     pub(crate) mod camera_window;
+    pub(crate) mod drawing_helpers;
+    pub(crate) mod drawing_window;
     pub(crate) mod screensharing_window;
     pub(crate) mod stats_window;
     pub(crate) mod vibrancy;
@@ -60,7 +62,6 @@ use camera::capturer::{poll_camera_stream, CameraCapturer};
 use capture::capturer::{poll_stream, Capturer};
 use graphics::graphics_context::GraphicsContext;
 use graphics::graphics_window_context::ContextManager;
-use image::GenericImageView;
 use input::clipboard::ClipboardController;
 use input::keyboard::{KeyboardController, KeyboardLayout};
 use input::mouse::CursorController;
@@ -78,6 +79,7 @@ use std::thread::JoinHandle;
 use thiserror::Error;
 use utils::geometry::{Extent, Frame};
 use window::camera_window::CameraWindow;
+use window::drawing_window::DrawingWindow;
 use window::screensharing_window::{ScreensharingWindow, ScreensharingWindowConfig};
 use window::stats_window::StatsWindow;
 use winit::application::ApplicationHandler;
@@ -150,7 +152,6 @@ struct RemoteControl<'a> {
     cursor_controller: CursorController,
     keyboard_controller: KeyboardController<KeyboardLayout>,
     clipboard_controller: Option<ClipboardController>,
-    pencil_cursor: winit::window::CustomCursor,
 }
 
 impl<'a> RemoteControl<'a> {
@@ -229,7 +230,7 @@ pub struct Application<'a> {
     socket_responses: std::sync::mpsc::Receiver<socket_lib::Message>,
     room_service: Option<RoomService>,
     event_loop_proxy: EventLoopProxy<UserEvent>,
-    local_drawing: LocalDrawing,
+    previous_controllers_enabled: bool,
     controller_draw_persist: bool,
     last_mode: Option<socket_lib::StoredMode>,
     window_manager: Option<window_manager::WindowManager>,
@@ -242,6 +243,8 @@ pub struct Application<'a> {
     context_manager: Option<ContextManager>,
     camera_window: Option<CameraWindow>,
     screensharing_window: Option<ScreensharingWindow>,
+    drawing_window: Option<DrawingWindow>,
+    drawing_redraw_thread: Option<JoinHandle<()>>,
     screensharing_redraw_thread: Option<JoinHandle<()>>,
     camera_redraw_thread: Option<JoinHandle<()>>,
     stats_window: Option<StatsWindow>,
@@ -252,34 +255,6 @@ pub struct Application<'a> {
 pub enum ApplicationError {
     #[error("Failed to create room service: {0}")]
     RoomServiceError(#[from] std::io::Error),
-}
-
-#[derive(Debug)]
-struct LocalDrawing {
-    enabled: bool,
-    permanent: bool,
-    left_mouse_pressed: bool,
-    current_path_id: u64,
-    last_cursor_position: Option<Position>,
-    previous_controllers_enabled: bool,
-    cursor_set_times: u32,
-}
-
-impl LocalDrawing {
-    fn reset(&mut self) {
-        self.enabled = false;
-        self.permanent = false;
-        self.left_mouse_pressed = false;
-        self.current_path_id = 0;
-        self.last_cursor_position = None;
-        self.previous_controllers_enabled = false;
-    }
-}
-
-impl fmt::Display for LocalDrawing {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "LocalDrawing: enabled: {} permanent: {} left_mouse_pressed: {} current_path_id: {} last_cursor_position: {:?}  previous_controllers_enabled: {}", self.enabled, self.permanent, self.left_mouse_pressed, self.current_path_id, self.last_cursor_position, self.previous_controllers_enabled)
-    }
 }
 
 impl<'a> Application<'a> {
@@ -332,15 +307,7 @@ impl<'a> Application<'a> {
             socket_responses,
             room_service: None,
             event_loop_proxy,
-            local_drawing: LocalDrawing {
-                enabled: false,
-                permanent: false,
-                left_mouse_pressed: false,
-                current_path_id: 0,
-                last_cursor_position: None,
-                previous_controllers_enabled: false,
-                cursor_set_times: 0,
-            },
+            previous_controllers_enabled: false,
             controller_draw_persist: false,
             last_mode: None,
             window_manager: None,
@@ -355,6 +322,8 @@ impl<'a> Application<'a> {
             context_manager: None,
             camera_window: None,
             screensharing_window: None,
+            drawing_window: None,
+            drawing_redraw_thread: None,
             screensharing_redraw_thread: None,
             camera_redraw_thread: None,
             stats_window: None,
@@ -568,6 +537,12 @@ impl<'a> Application<'a> {
         }
     }
 
+    fn join_drawing_redraw_thread(&mut self) {
+        if let Some(handle) = self.drawing_redraw_thread.take() {
+            let _ = handle.join();
+        }
+    }
+
     fn close_camera_window(&mut self) {
         log::info!("close_camera_window");
         if let Some(mut cam) = self.camera_window.take() {
@@ -580,6 +555,14 @@ impl<'a> Application<'a> {
         if let Some(mut window) = self.screensharing_window.take() {
             window.hide();
             self.screensharing_redraw_thread = window.take_redraw_thread();
+        }
+    }
+
+    fn close_drawing_window(&mut self) {
+        log::info!("close_drawing_window");
+        if let Some(mut window) = self.drawing_window.take() {
+            window.hide();
+            self.drawing_redraw_thread = window.take_redraw_thread();
         }
     }
 
@@ -655,37 +638,6 @@ impl<'a> Application<'a> {
                 ServerError::GfxCreationError
             })?;
 
-        // Load pencil cursor image once during window creation
-        let pencil_path = format!("{}/pencil.png", self.textures_path);
-        let pencil_image = image::open(&pencil_path).map_err(|e| {
-            log::error!("create_overlay_window: Failed to load pencil.png: {e:?}");
-            ServerError::GfxCreationError
-        })?;
-        let mut rgba = pencil_image.to_rgba8();
-        for pixel in rgba.chunks_exact_mut(4) {
-            let a = pixel[3] as f32 / 255.0;
-            pixel[0] = (pixel[0] as f32 * a) as u8;
-            pixel[1] = (pixel[1] as f32 * a) as u8;
-            pixel[2] = (pixel[2] as f32 * a) as u8;
-        }
-        let (width, height) = pencil_image.dimensions();
-        let hotspot_x = 0; // Pencil tip at top-left
-        let hotspot_y = height.saturating_sub(1); // Bottom of image (pencil tip)
-
-        let custom_cursor_source = winit::window::CustomCursor::from_rgba(
-            rgba.into_raw(),
-            width as u16,
-            height as u16,
-            hotspot_x as u16,
-            hotspot_y as u16,
-        )
-        .map_err(|e| {
-            log::error!("create_overlay_window: Failed to create cursor source: {e:?}");
-            ServerError::GfxCreationError
-        })?;
-
-        let pencil_cursor = event_loop.create_custom_cursor(custom_cursor_source);
-
         /* Hardcode window frame to zero as we only support displays for now.*/
         let window_frame = Frame::default();
         let scaled = {
@@ -755,11 +707,7 @@ impl<'a> Application<'a> {
             cursor_controller: cursor_controller.unwrap(),
             keyboard_controller: KeyboardController::<KeyboardLayout>::new(),
             clipboard_controller,
-            pencil_cursor,
         });
-
-        // Reset local drawing state on start of screenshare.
-        self.local_drawing.reset();
 
         #[cfg(target_os = "linux")]
         {
@@ -1034,6 +982,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
 
                 self.close_camera_window();
                 self.close_screensharing_window();
+                self.close_drawing_window();
                 self.stats_window = None;
 
                 if let Err(e) = self.socket.send(Message::CallEnded) {
@@ -1773,24 +1722,9 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                 }
 
                 let remote_control = &mut self.remote_control.as_mut().unwrap();
-                if !self.local_drawing.enabled {
-                    let window = remote_control.gfx.window();
-
-                    // Enable cursor hittest so we can receive mouse events
-                    if let Err(e) = window.set_cursor_hittest(true) {
-                        log::error!("user_event: Failed to enable cursor hittest: {e:?}");
-                        return;
-                    }
-
-                    // Enable drawing mode
-                    self.local_drawing.enabled = true;
-                    self.local_drawing.permanent = drawing_enabled.permanent;
-
-                    // Reset cursor set times counter
-                    self.local_drawing.cursor_set_times = 0;
-
+                if self.drawing_window.is_none() {
                     // Store the current controller state before disabling
-                    self.local_drawing.previous_controllers_enabled =
+                    self.previous_controllers_enabled =
                         remote_control.cursor_controller.is_controllers_enabled();
 
                     // Disable remote control
@@ -1802,12 +1736,29 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     let draw_mode = room_service::DrawingMode::Draw(room_service::DrawSettings {
                         permanent: drawing_enabled.permanent,
                     });
-                    remote_control
-                        .gfx
-                        .set_drawing_mode("local", draw_mode.clone());
 
                     if let Some(room_service) = &self.room_service {
                         room_service.publish_drawing_mode(draw_mode);
+                    }
+
+                    // Create and show drawing window
+                    let overlay_position = self
+                        .window_manager
+                        .as_ref()
+                        .and_then(|wm| wm.active_window_position());
+
+                    self.join_drawing_redraw_thread();
+
+                    match DrawingWindow::new(
+                        self.context_manager.as_ref().unwrap(),
+                        event_loop,
+                        drawing_enabled.permanent,
+                        overlay_position,
+                    ) {
+                        Ok(win) => self.drawing_window = Some(win),
+                        Err(e) => {
+                            log::error!("Failed to create drawing window: {e:?}");
+                        }
                     }
 
                     log::info!(
@@ -1815,43 +1766,18 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                         drawing_enabled.permanent
                     );
                 } else {
-                    // Disable drawing mode
-                    self.local_drawing.enabled = false;
-                    self.local_drawing.left_mouse_pressed = false;
-                    self.local_drawing.last_cursor_position = None;
-
-                    // Clear all local drawing paths
-                    remote_control.gfx.draw_clear_all_paths("local");
-
                     // Send LiveKit event to clear all paths
                     if let Some(room_service) = &self.room_service {
                         room_service.publish_draw_clear_all_paths();
                     }
 
-                    let window = remote_control.gfx.window();
-
-                    // Restore default cursor
-                    window.set_cursor(winit::window::Cursor::Icon(
-                        winit::window::CursorIcon::Default,
-                    ));
-
-                    // Disable cursor hittest
-                    if let Err(e) = window.set_cursor_hittest(false) {
-                        log::error!("user_event: Failed to disable cursor hittest: {e:?}");
-                    }
-
                     // Restore remote control to previous state
                     remote_control
                         .cursor_controller
-                        .set_controllers_enabled(self.local_drawing.previous_controllers_enabled);
+                        .set_controllers_enabled(self.previous_controllers_enabled);
                     remote_control
                         .keyboard_controller
-                        .set_enabled(self.local_drawing.previous_controllers_enabled);
-
-                    // Set drawing mode to disabled for local participant
-                    remote_control
-                        .gfx
-                        .set_drawing_mode("local", room_service::DrawingMode::Disabled);
+                        .set_enabled(self.previous_controllers_enabled);
 
                     if let Some(room_service) = &self.room_service {
                         room_service.publish_drawing_mode(room_service::DrawingMode::Disabled);
@@ -1860,6 +1786,9 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     log::info!("Local drawing mode disabled");
 
                     remote_control.gfx.trigger_render();
+
+                    // Hide drawing window
+                    self.close_drawing_window();
                 }
             }
         }
@@ -1895,6 +1824,57 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
         if let Some(camera) = &mut self.camera_window {
             if camera.window_id() == window_id {
                 camera.handle_window_event(event);
+                return;
+            }
+        }
+
+        // Route to drawing window if it matches
+        if let Some(drawing) = &mut self.drawing_window {
+            if drawing.window_id() == window_id {
+                let input_event = drawing.handle_window_event(event);
+                if let Some(event) = input_event {
+                    if let Some(rs) = &self.room_service {
+                        match event {
+                            window::drawing_window::DrawingWindowInputEvent::DrawStart {
+                                x,
+                                y,
+                                path_id,
+                            } => {
+                                rs.publish_draw_start(crate::room_service::DrawPathPoint {
+                                    point: crate::room_service::ClientPoint { x, y },
+                                    path_id,
+                                });
+                            }
+                            window::drawing_window::DrawingWindowInputEvent::DrawAddPoint {
+                                x,
+                                y,
+                            } => {
+                                rs.publish_draw_add_point(crate::room_service::ClientPoint {
+                                    x,
+                                    y,
+                                });
+                            }
+                            window::drawing_window::DrawingWindowInputEvent::DrawEnd { x, y } => {
+                                rs.publish_draw_end(crate::room_service::ClientPoint { x, y });
+                            }
+                            window::drawing_window::DrawingWindowInputEvent::DrawClearAllPaths => {
+                                rs.publish_draw_clear_all_paths();
+                            }
+                            window::drawing_window::DrawingWindowInputEvent::DrawClearPaths(
+                                ids,
+                            ) => {
+                                rs.publish_draw_clear_paths(ids);
+                            }
+                            window::drawing_window::DrawingWindowInputEvent::Escape => {
+                                let _ = self.event_loop_proxy.send_event(
+                                    UserEvent::LocalDrawingEnabled(socket_lib::DrawingEnabled {
+                                        permanent: false,
+                                    }),
+                                );
+                            }
+                        }
+                    }
+                }
                 return;
             }
         }
@@ -2041,16 +2021,8 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                 }
                 let remote_control = &mut self.remote_control.as_mut().unwrap();
 
-                if self.local_drawing.enabled && self.local_drawing.cursor_set_times < 500 {
-                    let window = remote_control.gfx.window();
-                    window.focus_window();
-                    window.set_cursor_visible(false);
-                    window.set_cursor_visible(true);
-                    window.set_cursor(remote_control.pencil_cursor.clone());
-                    self.local_drawing.cursor_set_times += 1;
-                }
-
                 // Render frame with cursor updates, auto-clear, and drawing
+                // TODO: cleared path ids is not used anymore from here
                 let cleared_path_ids = remote_control.render_frame();
 
                 // Publish cleared paths to room service
@@ -2059,128 +2031,6 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                         .as_ref()
                         .unwrap()
                         .publish_draw_clear_paths(cleared_path_ids);
-                }
-            }
-            WindowEvent::MouseInput { state, button, .. } => {
-                if self.local_drawing.enabled {
-                    if button == winit::event::MouseButton::Left {
-                        if state == winit::event::ElementState::Pressed {
-                            self.local_drawing.left_mouse_pressed = true;
-                            // Start a new path if we have a cursor position
-                            if let Some(position) = self.local_drawing.last_cursor_position {
-                                if let Some(remote_control) = &mut self.remote_control {
-                                    self.local_drawing.current_path_id += 1;
-                                    remote_control.gfx.draw_start(
-                                        "local",
-                                        position,
-                                        self.local_drawing.current_path_id,
-                                    );
-                                    remote_control.gfx.trigger_render();
-
-                                    // Send LiveKit event
-                                    if let Some(room_service) = &self.room_service {
-                                        room_service.publish_draw_start(
-                                            room_service::DrawPathPoint {
-                                                point: room_service::ClientPoint {
-                                                    x: position.x,
-                                                    y: position.y,
-                                                },
-                                                path_id: self.local_drawing.current_path_id,
-                                            },
-                                        );
-                                    }
-
-                                    log::debug!(
-                                        "Local draw_start at {:?} with path_id {}",
-                                        position,
-                                        self.local_drawing.current_path_id
-                                    );
-                                }
-                            }
-                        } else {
-                            self.local_drawing.left_mouse_pressed = false;
-                            // End the current path
-                            if let Some(position) = self.local_drawing.last_cursor_position {
-                                if let Some(remote_control) = &mut self.remote_control {
-                                    remote_control.gfx.draw_end("local", position);
-                                    remote_control.gfx.trigger_render();
-
-                                    // Send LiveKit event
-                                    if let Some(room_service) = &self.room_service {
-                                        room_service.publish_draw_end(room_service::ClientPoint {
-                                            x: position.x,
-                                            y: position.y,
-                                        });
-                                    }
-
-                                    log::debug!("Local draw_end at {:?}", position);
-                                }
-                            }
-                        }
-                    } else if button == winit::event::MouseButton::Right
-                        && state == winit::event::ElementState::Pressed
-                    {
-                        if let Some(remote_control) = &mut self.remote_control {
-                            // Clear all local drawing paths
-                            remote_control.gfx.draw_clear_all_paths("local");
-                            remote_control.gfx.trigger_render();
-
-                            // Send LiveKit event to clear all paths
-                            if let Some(room_service) = &self.room_service {
-                                room_service.publish_draw_clear_all_paths();
-                            }
-                            log::debug!("Local draw_clear_all_paths on right click");
-                        }
-                    }
-                }
-            }
-            WindowEvent::CursorMoved { position, .. } => {
-                if self.local_drawing.enabled {
-                    // Convert physical position to percentage (0.0–1.0)
-                    let pos = if let Some(remote_control) = &self.remote_control {
-                        let overlay_window = remote_control.cursor_controller.get_overlay_window();
-                        let scale = overlay_window.get_display_scale();
-                        overlay_window
-                            .get_local_percentage_from_pixel(position.x / scale, position.y / scale)
-                    } else {
-                        Position {
-                            x: position.x,
-                            y: position.y,
-                        }
-                    };
-                    self.local_drawing.last_cursor_position = Some(pos);
-
-                    // If we're actively drawing, add a point
-                    if self.local_drawing.left_mouse_pressed {
-                        if let Some(remote_control) = &mut self.remote_control {
-                            remote_control.gfx.draw_add_point("local", pos);
-                            remote_control.gfx.trigger_render();
-
-                            // Send LiveKit event
-                            if let Some(room_service) = &self.room_service {
-                                room_service.publish_draw_add_point(room_service::ClientPoint {
-                                    x: pos.x,
-                                    y: pos.y,
-                                });
-                            }
-                        }
-                    }
-                }
-            }
-            WindowEvent::KeyboardInput { event, .. } => {
-                if self.local_drawing.enabled && event.state == winit::event::ElementState::Pressed
-                {
-                    if let winit::keyboard::Key::Named(winit::keyboard::NamedKey::Escape) =
-                        event.logical_key
-                    {
-                        // Disable drawing mode
-                        let _ = self
-                            .event_loop_proxy
-                            .send_event(UserEvent::LocalDrawingEnabled(
-                                socket_lib::DrawingEnabled { permanent: false },
-                            ));
-                        log::debug!("Escape pressed, disabling local drawing");
-                    }
                 }
             }
             WindowEvent::Resized(_size) => {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1736,11 +1736,13 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     return;
                 }
 
-                let remote_control = &mut self.remote_control.as_mut().unwrap();
                 if self.drawing_window.is_none() {
+                    let remote_control = self.remote_control.as_mut().unwrap();
+
                     // Store the current controller state before disabling
-                    self.previous_controllers_enabled =
+                    let previous_controllers_enabled =
                         remote_control.cursor_controller.is_controllers_enabled();
+                    self.previous_controllers_enabled = previous_controllers_enabled;
 
                     // Disable remote control
                     remote_control
@@ -1770,17 +1772,34 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                         drawing_enabled.permanent,
                         overlay_position,
                     ) {
-                        Ok(win) => self.drawing_window = Some(win),
+                        Ok(win) => {
+                            self.drawing_window = Some(win);
+                            log::info!(
+                                "Local drawing mode enabled (permanent: {})",
+                                drawing_enabled.permanent
+                            );
+                        }
                         Err(e) => {
                             log::error!("Failed to create drawing window: {e:?}");
+
+                            // Restore remote control to previous state
+                            let remote_control = self.remote_control.as_mut().unwrap();
+                            remote_control
+                                .cursor_controller
+                                .set_controllers_enabled(previous_controllers_enabled);
+                            remote_control
+                                .keyboard_controller
+                                .set_enabled(previous_controllers_enabled);
+
+                            if let Some(room_service) = &self.room_service {
+                                room_service
+                                    .publish_drawing_mode(room_service::DrawingMode::Disabled);
+                            }
                         }
                     }
-
-                    log::info!(
-                        "Local drawing mode enabled (permanent: {})",
-                        drawing_enabled.permanent
-                    );
                 } else {
+                    let remote_control = self.remote_control.as_mut().unwrap();
+
                     // Send LiveKit event to clear all paths
                     if let Some(room_service) = &self.room_service {
                         room_service.publish_draw_clear_all_paths();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1708,6 +1708,17 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     }
                 }
             }
+            UserEvent::SharerDrawPersistChanged(persist) => {
+                log::info!("user_event: SharerDrawPersistChanged: {persist}");
+                if let Some(drawing_window) = &mut self.drawing_window {
+                    drawing_window.set_draw_persist(persist);
+                }
+                if let Some(room_service) = &self.room_service {
+                    room_service.publish_drawing_mode(room_service::DrawingMode::Draw(
+                        room_service::DrawSettings { permanent: persist },
+                    ));
+                }
+            }
             UserEvent::ControllerDrawPersistChanged(persist) => {
                 self.controller_draw_persist = persist;
             }
@@ -2145,6 +2156,7 @@ pub enum UserEvent {
     DrawClearAllPaths(String),
     ClickAnimationFromParticipant(room_service::ClientPoint, String),
     LocalDrawingEnabled(socket_lib::DrawingEnabled),
+    SharerDrawPersistChanged(bool),
     ControllerDrawPersistChanged(bool),
     LastModeChanged(socket_lib::StoredMode),
     ListAudioDevices,
@@ -2299,6 +2311,9 @@ impl RenderEventLoop {
                         UserEvent::ControllerCursorEnabled(enabled)
                     }
                     Message::DrawingEnabled(permanent) => UserEvent::LocalDrawingEnabled(permanent),
+                    Message::SharerDrawPersistChanged(persist) => {
+                        UserEvent::SharerDrawPersistChanged(persist)
+                    }
                     Message::ControllerDrawPersistChanged(persist) => {
                         UserEvent::ControllerDrawPersistChanged(persist)
                     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -564,6 +564,9 @@ impl<'a> Application<'a> {
             window.hide();
             self.drawing_redraw_thread = window.take_redraw_thread();
         }
+        if let Err(e) = self.socket.send(Message::DrawingDisabled) {
+            log::error!("Failed to send DrawingDisabled: {e:?}");
+        }
     }
 
     fn stop_screenshare(&mut self) {
@@ -581,6 +584,7 @@ impl<'a> Application<'a> {
         }
         self.destroy_overlay_window();
         self.set_screensharing_active(false);
+        self.close_drawing_window();
     }
 
     fn set_screensharing_active(&mut self, active: bool) {
@@ -1844,6 +1848,16 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
             if drawing.window_id() == window_id {
                 let input_event = drawing.handle_window_event(event);
                 if let Some(event) = input_event {
+                    if matches!(
+                        event,
+                        window::drawing_window::DrawingWindowInputEvent::Escape
+                    ) {
+                        let _ = self
+                            .event_loop_proxy
+                            .send_event(UserEvent::LocalDrawingEnabled(
+                                socket_lib::DrawingEnabled { permanent: false },
+                            ));
+                    }
                     if let Some(rs) = &self.room_service {
                         match event {
                             window::drawing_window::DrawingWindowInputEvent::DrawStart {
@@ -1876,13 +1890,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                             ) => {
                                 rs.publish_draw_clear_paths(ids);
                             }
-                            window::drawing_window::DrawingWindowInputEvent::Escape => {
-                                let _ = self.event_loop_proxy.send_event(
-                                    UserEvent::LocalDrawingEnabled(socket_lib::DrawingEnabled {
-                                        permanent: false,
-                                    }),
-                                );
-                            }
+                            window::drawing_window::DrawingWindowInputEvent::Escape => {}
                         }
                     }
                 }

--- a/core/src/window/drawing_helpers.rs
+++ b/core/src/window/drawing_helpers.rs
@@ -1,0 +1,134 @@
+use iced::widget::canvas;
+use iced::{Rectangle, Theme};
+use iced_wgpu::core::mouse;
+
+use fontdb::Database;
+use resvg::{tiny_skia, usvg};
+
+use crate::graphics::graphics_context::click_animation::ClickAnimationRenderer;
+use crate::graphics::graphics_context::participant::ParticipantsManager;
+use crate::utils::geometry::Position;
+
+pub(crate) const LOCAL_PARTICIPANT_IDENTITY: &str = "local";
+pub(crate) const CURSOR_LOGICAL_SIZE: f64 = 30.0;
+
+pub(crate) const CURSOR_ICON_PENCIL: &[u8] =
+    include_bytes!("../../resources/icons/local-participant-pencil.svg");
+pub(crate) const CURSOR_ICON_POINTER: &[u8] =
+    include_bytes!("../../resources/icons/local-participant-cursor.svg");
+pub(crate) const CURSOR_ICON_POINT: &[u8] =
+    include_bytes!("../../resources/icons/local-participant-pointer.svg");
+
+pub(crate) fn rasterize_svg_to_rgba(svg_bytes: &[u8], px_size: u32) -> (Vec<u8>, u32, u32) {
+    let fontdb = std::sync::Arc::new(Database::new());
+    let usvg_options = usvg::Options {
+        fontdb,
+        ..Default::default()
+    };
+    let tree = usvg::Tree::from_data(svg_bytes, &usvg_options)
+        .expect("rasterize_svg_to_rgba: failed to parse cursor SVG");
+    let svg_size = tree.size();
+    let max_dim = svg_size.width().max(svg_size.height());
+    let scale = if max_dim > 0.0 {
+        px_size as f32 / max_dim
+    } else {
+        1.0
+    };
+    let w = (svg_size.width() * scale).ceil().max(1.0) as u32;
+    let h = (svg_size.height() * scale).ceil().max(1.0) as u32;
+    let mut pixmap = tiny_skia::Pixmap::new(w, h).expect("rasterize_svg_to_rgba: pixmap");
+    resvg::render(
+        &tree,
+        tiny_skia::Transform::from_scale(scale, scale),
+        &mut pixmap.as_mut(),
+    );
+    let mut rgba = pixmap.data().to_vec();
+    for px in rgba.chunks_exact_mut(4) {
+        let a = px[3] as f32;
+        if a > 0.0 && a < 255.0 {
+            let inv = 255.0 / a;
+            px[0] = (px[0] as f32 * inv).round().min(255.0) as u8;
+            px[1] = (px[1] as f32 * inv).round().min(255.0) as u8;
+            px[2] = (px[2] as f32 * inv).round().min(255.0) as u8;
+        }
+    }
+    (rgba, w, h)
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn create_macos_cursor(
+    rgba: &[u8],
+    pixel_w: u32,
+    pixel_h: u32,
+    logical_w: f64,
+    logical_h: f64,
+    hotspot_x: f64,
+    hotspot_y: f64,
+) -> objc2::rc::Retained<objc2_app_kit::NSCursor> {
+    use objc2::rc::Retained;
+    use objc2::AnyThread;
+    use objc2_app_kit::{NSBitmapImageRep, NSCursor, NSImage, NSImageRep};
+    use objc2_foundation::{NSPoint, NSSize};
+
+    unsafe {
+        let planes_ptr: *mut *mut u8 = std::ptr::null_mut();
+        let rep: Retained<NSBitmapImageRep> = objc2::msg_send![
+            NSBitmapImageRep::alloc(),
+            initWithBitmapDataPlanes: planes_ptr,
+            pixelsWide: pixel_w as isize,
+            pixelsHigh: pixel_h as isize,
+            bitsPerSample: 8_isize,
+            samplesPerPixel: 4_isize,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: objc2_app_kit::NSDeviceRGBColorSpace,
+            bytesPerRow: (pixel_w * 4) as isize,
+            bitsPerPixel: 32_isize
+        ];
+
+        let bitmap_data: *mut u8 = objc2::msg_send![&rep, bitmapData];
+        std::ptr::copy_nonoverlapping(rgba.as_ptr(), bitmap_data, rgba.len());
+
+        let image = NSImage::new();
+        let rep_as_imagerep: &NSImageRep =
+            &*((&rep as &NSBitmapImageRep) as *const NSBitmapImageRep as *const NSImageRep);
+        image.addRepresentation(rep_as_imagerep);
+        image.setSize(NSSize::new(logical_w, logical_h));
+
+        NSCursor::initWithImage_hotSpot(
+            NSCursor::alloc(),
+            &image,
+            NSPoint::new(hotspot_x, hotspot_y),
+        )
+    }
+}
+
+pub(crate) struct ParticipantOverlay<'a> {
+    pub(crate) participants: &'a ParticipantsManager,
+    pub(crate) click_animation_renderer: Option<&'a ClickAnimationRenderer>,
+}
+
+impl<'a, Message> canvas::Program<Message> for ParticipantOverlay<'a> {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &(),
+        renderer: &iced::Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<canvas::Geometry> {
+        let translate = |pos: Position| -> Position {
+            Position {
+                x: pos.x * bounds.width as f64,
+                y: pos.y * bounds.height as f64,
+            }
+        };
+        let mut geometries = self.participants.draw(renderer, bounds, &translate);
+        if let Some(click_renderer) = self.click_animation_renderer {
+            geometries.push(click_renderer.draw(renderer, bounds, &translate));
+        }
+        geometries
+    }
+}

--- a/core/src/window/drawing_window.rs
+++ b/core/src/window/drawing_window.rs
@@ -154,7 +154,6 @@ pub struct DrawingWindow {
     ns_cursor_pencil: objc2::rc::Retained<objc2_app_kit::NSCursor>,
     #[cfg(not(target_os = "macos"))]
     custom_cursor_pencil: winit::window::CustomCursor,
-    pencil_cursor_counter: u8,
 }
 
 impl DrawingWindow {
@@ -248,7 +247,7 @@ impl DrawingWindow {
         let (redraw_tx, redraw_rx) = std::sync::mpsc::channel();
         let redraw_thread = Some(spawn_redraw_thread(redraw_rx, window.clone()));
 
-        let mut s = Self {
+        let s = Self {
             window,
             surface,
             device,
@@ -271,9 +270,8 @@ impl DrawingWindow {
             ns_cursor_pencil,
             #[cfg(not(target_os = "macos"))]
             custom_cursor_pencil,
-            pencil_cursor_counter: 0,
         };
-        s.set_pencil_cursor(true);
+        s.set_pencil_cursor();
         Ok(s)
     }
 
@@ -318,10 +316,7 @@ impl DrawingWindow {
         }
     }
 
-    fn set_pencil_cursor(&mut self, reset_counter: bool) {
-        if reset_counter {
-            self.pencil_cursor_counter = 20;
-        }
+    fn set_pencil_cursor(&self) {
         #[cfg(target_os = "macos")]
         {
             self.ns_cursor_pencil.set();
@@ -374,7 +369,7 @@ impl DrawingWindow {
             }
             WindowEvent::CursorEntered { .. } => {
                 log::info!("drawing_window: cursor entered");
-                self.set_pencil_cursor(true);
+                self.set_pencil_cursor();
             }
             WindowEvent::CursorLeft { .. } => {
                 if self.left_mouse_pressed {
@@ -391,7 +386,7 @@ impl DrawingWindow {
                 self.set_default_cursor();
             }
             WindowEvent::Focused(true) => {
-                self.set_pencil_cursor(true);
+                self.set_pencil_cursor();
             }
             WindowEvent::Focused(false) => {
                 if self.left_mouse_pressed {
@@ -408,6 +403,7 @@ impl DrawingWindow {
                 self.set_default_cursor();
             }
             WindowEvent::MouseInput { state, button, .. } => {
+                self.set_pencil_cursor();
                 let (pct_x, pct_y) = match &self.cursor {
                     mouse::Cursor::Available(pos) => {
                         let physical_size = self.window.inner_size();
@@ -549,11 +545,6 @@ impl DrawingWindow {
     }
 
     fn redraw(&mut self) -> Vec<u64> {
-        if self.pencil_cursor_counter > 0 {
-            self.set_pencil_cursor(false);
-            self.pencil_cursor_counter -= 1;
-        }
-
         self.participants_manager.hide_inactive_cursors();
 
         let cleared = self.participants_manager.update_auto_clear();

--- a/core/src/window/drawing_window.rs
+++ b/core/src/window/drawing_window.rs
@@ -179,6 +179,22 @@ impl DrawingWindow {
 
         window.focus_window();
 
+        #[cfg(target_os = "macos")]
+        {
+            use objc2::rc::Retained;
+            use objc2_app_kit::NSView;
+            use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+            if let Ok(raw_handle) = window.window_handle() {
+                if let RawWindowHandle::AppKit(handle) = raw_handle.as_raw() {
+                    let ns_view: Option<Retained<NSView>> =
+                        unsafe { Retained::retain(handle.ns_view.as_ptr().cast()) };
+                    if let Some(ns_window) = ns_view.and_then(|v| v.window()) {
+                        ns_window.disableCursorRects();
+                    }
+                }
+            }
+        }
+
         let surface_info =
             context_manager
                 .create_drawing_surface(&window)
@@ -271,7 +287,6 @@ impl DrawingWindow {
             #[cfg(not(target_os = "macos"))]
             custom_cursor_pencil,
         };
-        s.set_pencil_cursor();
         Ok(s)
     }
 

--- a/core/src/window/drawing_window.rs
+++ b/core/src/window/drawing_window.rs
@@ -296,6 +296,14 @@ impl DrawingWindow {
         self.window.set_visible(false);
     }
 
+    pub fn set_draw_persist(&mut self, permanent: bool) {
+        self.draw_persist = permanent;
+        self.participants_manager.set_drawing_mode(
+            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+            crate::room_service::DrawingMode::Draw(crate::room_service::DrawSettings { permanent }),
+        );
+    }
+
     fn set_default_cursor(&self) {
         #[cfg(target_os = "macos")]
         {

--- a/core/src/window/drawing_window.rs
+++ b/core/src/window/drawing_window.rs
@@ -11,6 +11,7 @@ use iced_winit::runtime::user_interface::Cache;
 use iced_winit::runtime::UserInterface;
 use iced_winit::{conversion, Clipboard};
 use winit::event::WindowEvent;
+use winit::dpi::LogicalSize;
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::{Key, ModifiersState, NamedKey};
 use winit::window::{Window, WindowAttributes, WindowId};
@@ -31,6 +32,10 @@ pub fn drawing_window_attributes() -> WindowAttributes {
         .with_decorations(false)
         .with_transparent(true)
         .with_content_protected(true)
+        .with_inner_size(LogicalSize::new(
+            1.0,
+            1.0,
+        ))
         .with_window_level(WindowLevel::AlwaysOnTop);
 
     #[cfg(target_os = "macos")]
@@ -166,7 +171,6 @@ impl DrawingWindow {
         log::info!("DrawingWindow::new");
 
         let mut window_attributes = drawing_window_attributes();
-        window_attributes = window_attributes.with_maximized(true);
         if let Some(pos) = position {
             window_attributes = window_attributes.with_position(pos);
         }
@@ -177,6 +181,7 @@ impl DrawingWindow {
         })?;
         let window = Arc::new(window);
 
+        window.set_maximized(true);
         window.focus_window();
 
         #[cfg(target_os = "macos")]
@@ -229,26 +234,32 @@ impl DrawingWindow {
         );
         let clipboard = Clipboard::connect(window.clone());
 
-        let px = (drawing_helpers::CURSOR_LOGICAL_SIZE * 4.0).round() as u32;
-        let (pencil_rgba, ew, eh) =
-            drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_PENCIL, px);
-
         #[cfg(target_os = "macos")]
-        let ns_cursor_pencil = drawing_helpers::create_macos_cursor(
-            &pencil_rgba,
-            ew,
-            eh,
-            drawing_helpers::CURSOR_LOGICAL_SIZE,
-            drawing_helpers::CURSOR_LOGICAL_SIZE,
-            2.0,
-            29.0,
-        );
+        let ns_cursor_pencil = {
+            let px = (drawing_helpers::CURSOR_LOGICAL_SIZE * 4.0).round() as u32;
+            let (pencil_rgba, ew, eh) =
+                drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_PENCIL, px);
+            drawing_helpers::create_macos_cursor(
+                &pencil_rgba,
+                ew,
+                eh,
+                drawing_helpers::CURSOR_LOGICAL_SIZE,
+                drawing_helpers::CURSOR_LOGICAL_SIZE,
+                2.0,
+                29.0,
+            )
+        };
 
         #[cfg(not(target_os = "macos"))]
-        let custom_cursor_pencil = event_loop.create_custom_cursor(
-            winit::window::CustomCursor::from_rgba(pencil_rgba, ew as u16, eh as u16, 2, 29)
-                .expect("create pencil cursor"),
-        );
+        let custom_cursor_pencil = {
+            let px = drawing_helpers::CURSOR_LOGICAL_SIZE as u32;
+            let (pencil_rgba, ew, eh) =
+                drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_PENCIL, px);
+            event_loop.create_custom_cursor(
+                winit::window::CustomCursor::from_rgba(pencil_rgba, ew as u16, eh as u16, 2, 29)
+                    .expect("create pencil cursor"),
+            )
+        };
 
         let mut participants_manager = ParticipantsManager::new();
         if let Err(e) = participants_manager.add_participant(

--- a/core/src/window/drawing_window.rs
+++ b/core/src/window/drawing_window.rs
@@ -1,0 +1,609 @@
+use std::sync::Arc;
+
+use iced::widget::{canvas, container};
+use iced::{Background, Color, Length, Rectangle, Theme};
+use iced_wgpu::core::mouse;
+use iced_wgpu::graphics::Viewport;
+use iced_winit::core::renderer::Style;
+use iced_winit::core::time::Instant;
+use iced_winit::core::{window, Event, Size};
+use iced_winit::runtime::user_interface::Cache;
+use iced_winit::runtime::UserInterface;
+use iced_winit::{conversion, Clipboard};
+use winit::event::WindowEvent;
+use winit::event_loop::ActiveEventLoop;
+use winit::keyboard::{Key, ModifiersState, NamedKey};
+use winit::window::{Window, WindowAttributes, WindowId};
+
+use thiserror::Error;
+
+use crate::components::fonts::{self as fonts_mod, GEIST_REGULAR};
+use crate::graphics::graphics_context::participant::ParticipantsManager;
+use crate::graphics::graphics_window_context::{ContextManager, GraphicsWindowContextError};
+use crate::room_service::DrawingMode;
+use crate::utils::geometry::Position;
+use crate::window::drawing_helpers;
+
+pub fn drawing_window_attributes() -> WindowAttributes {
+    use winit::window::WindowLevel;
+    let attrs = WindowAttributes::default()
+        .with_title("Hopp Drawing")
+        .with_decorations(false)
+        .with_transparent(true)
+        .with_content_protected(true)
+        .with_window_level(WindowLevel::AlwaysOnTop);
+
+    #[cfg(target_os = "macos")]
+    let attrs = {
+        use winit::platform::macos::WindowAttributesExtMacOS;
+        attrs
+            .with_title_hidden(true)
+            .with_titlebar_transparent(true)
+            .with_fullsize_content_view(true)
+    };
+    attrs
+}
+
+pub(crate) enum RedrawCommand {
+    Activity,
+    Stop,
+}
+
+fn spawn_redraw_thread(
+    redraw_rx: std::sync::mpsc::Receiver<RedrawCommand>,
+    window: Arc<Window>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let redraw_interval = std::time::Duration::from_millis(16);
+        let inactivity_timeout = std::time::Duration::from_secs(15);
+        let mut last_activity_time = std::time::Instant::now();
+
+        loop {
+            match redraw_rx.recv_timeout(redraw_interval) {
+                Ok(RedrawCommand::Stop) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                    break
+                }
+                Ok(RedrawCommand::Activity) => {
+                    if last_activity_time.elapsed() < redraw_interval {
+                        continue;
+                    }
+                    last_activity_time = std::time::Instant::now();
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            }
+
+            if last_activity_time.elapsed() > inactivity_timeout {
+                continue;
+            }
+
+            window.request_redraw();
+        }
+    })
+}
+
+#[derive(Error, Debug)]
+pub enum DrawingWindowError {
+    #[error("Failed to create window")]
+    WindowCreation,
+    #[error("Failed to create wgpu surface")]
+    SurfaceCreation,
+    #[error("No suitable GPU adapter found")]
+    AdapterRequest,
+    #[error("Failed to request GPU device")]
+    DeviceRequest,
+}
+
+#[derive(Debug)]
+pub(crate) enum DrawingWindowInputEvent {
+    DrawStart { x: f64, y: f64, path_id: u64 },
+    DrawAddPoint { x: f64, y: f64 },
+    DrawEnd { x: f64, y: f64 },
+    DrawClearAllPaths,
+    DrawClearPaths(Vec<u64>),
+    Escape,
+}
+
+#[derive(Debug, Clone)]
+pub enum DrawingMessage {}
+
+struct DrawingOverlay<'a> {
+    participants: &'a ParticipantsManager,
+}
+
+impl<'a, Message> iced::widget::canvas::Program<Message> for DrawingOverlay<'a> {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &(),
+        renderer: &iced::Renderer,
+        _theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<iced::widget::canvas::Geometry> {
+        let translate = |pos: Position| -> Position {
+            Position {
+                x: pos.x * bounds.width as f64,
+                y: pos.y * bounds.height as f64,
+            }
+        };
+        self.participants.draw(renderer, bounds, &translate)
+    }
+}
+
+pub struct DrawingWindow {
+    window: Arc<Window>,
+    surface: wgpu::Surface<'static>,
+    device: wgpu::Device,
+    format: wgpu::TextureFormat,
+    alpha_mode: wgpu::CompositeAlphaMode,
+    renderer: iced::Renderer,
+    viewport: Viewport,
+    cache: Option<Cache>,
+    clipboard: Clipboard,
+    cursor: mouse::Cursor,
+    modifiers: ModifiersState,
+    left_mouse_pressed: bool,
+    current_path_id: u64,
+    last_cursor_position: Option<(f64, f64)>,
+    draw_persist: bool,
+    participants_manager: ParticipantsManager,
+    redraw_thread: Option<std::thread::JoinHandle<()>>,
+    redraw_tx: std::sync::mpsc::Sender<RedrawCommand>,
+    #[cfg(target_os = "macos")]
+    ns_cursor_pencil: objc2::rc::Retained<objc2_app_kit::NSCursor>,
+    #[cfg(not(target_os = "macos"))]
+    custom_cursor_pencil: winit::window::CustomCursor,
+    pencil_cursor_counter: u8,
+}
+
+impl DrawingWindow {
+    pub fn new(
+        context_manager: &ContextManager,
+        event_loop: &ActiveEventLoop,
+        permanent: bool,
+        position: Option<winit::dpi::LogicalPosition<f64>>,
+    ) -> Result<Self, DrawingWindowError> {
+        log::info!("DrawingWindow::new");
+
+        let mut window_attributes = drawing_window_attributes();
+        window_attributes = window_attributes.with_maximized(true);
+        if let Some(pos) = position {
+            window_attributes = window_attributes.with_position(pos);
+        }
+
+        let window = event_loop.create_window(window_attributes).map_err(|e| {
+            log::error!("DrawingWindow: failed to create window: {e:?}");
+            DrawingWindowError::WindowCreation
+        })?;
+        let window = Arc::new(window);
+
+        window.focus_window();
+
+        let surface_info =
+            context_manager
+                .create_drawing_surface(&window)
+                .map_err(|e| match e {
+                    GraphicsWindowContextError::SurfaceCreation => {
+                        DrawingWindowError::SurfaceCreation
+                    }
+                    GraphicsWindowContextError::AdapterRequest => {
+                        DrawingWindowError::AdapterRequest
+                    }
+                    GraphicsWindowContextError::DeviceRequest => DrawingWindowError::DeviceRequest,
+                })?;
+        let device = context_manager.drawing_context.device.clone();
+        let format = surface_info.format;
+        let alpha_mode = surface_info.alpha_mode;
+        let surface = surface_info.surface;
+        let physical_size = window.inner_size();
+
+        let wgpu_renderer = iced_wgpu::Renderer::new(
+            context_manager.drawing_context.engine.clone(),
+            GEIST_REGULAR,
+            iced::Pixels::from(16),
+        );
+
+        fonts_mod::load_fonts();
+
+        let renderer = iced::Renderer::Primary(wgpu_renderer);
+
+        let viewport = Viewport::with_physical_size(
+            Size::new(physical_size.width.max(1), physical_size.height.max(1)),
+            window.scale_factor() as f32,
+        );
+        let clipboard = Clipboard::connect(window.clone());
+
+        let px = (drawing_helpers::CURSOR_LOGICAL_SIZE * 4.0).round() as u32;
+        let (pencil_rgba, ew, eh) =
+            drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_PENCIL, px);
+
+        #[cfg(target_os = "macos")]
+        let ns_cursor_pencil = drawing_helpers::create_macos_cursor(
+            &pencil_rgba,
+            ew,
+            eh,
+            drawing_helpers::CURSOR_LOGICAL_SIZE,
+            drawing_helpers::CURSOR_LOGICAL_SIZE,
+            2.0,
+            29.0,
+        );
+
+        #[cfg(not(target_os = "macos"))]
+        let custom_cursor_pencil = event_loop.create_custom_cursor(
+            winit::window::CustomCursor::from_rgba(pencil_rgba, ew as u16, eh as u16, 2, 29)
+                .expect("create pencil cursor"),
+        );
+
+        let mut participants_manager = ParticipantsManager::new();
+        if let Err(e) = participants_manager.add_participant(
+            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY.to_string(),
+            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+            true,
+            DrawingMode::Draw(crate::room_service::DrawSettings { permanent }),
+        ) {
+            log::warn!("DrawingWindow::new: failed to add local participant: {e:?}");
+        }
+
+        let (redraw_tx, redraw_rx) = std::sync::mpsc::channel();
+        let redraw_thread = Some(spawn_redraw_thread(redraw_rx, window.clone()));
+
+        let mut s = Self {
+            window,
+            surface,
+            device,
+            format,
+            alpha_mode,
+            renderer,
+            viewport,
+            cache: Some(Cache::default()),
+            clipboard,
+            cursor: mouse::Cursor::Unavailable,
+            modifiers: ModifiersState::default(),
+            left_mouse_pressed: false,
+            current_path_id: 0,
+            last_cursor_position: None,
+            draw_persist: permanent,
+            participants_manager,
+            redraw_thread,
+            redraw_tx,
+            #[cfg(target_os = "macos")]
+            ns_cursor_pencil,
+            #[cfg(not(target_os = "macos"))]
+            custom_cursor_pencil,
+            pencil_cursor_counter: 0,
+        };
+        s.set_pencil_cursor(true);
+        Ok(s)
+    }
+
+    pub fn window_id(&self) -> WindowId {
+        self.window.id()
+    }
+
+    fn signal_activity(&self) {
+        let _ = self.redraw_tx.send(RedrawCommand::Activity);
+    }
+
+    pub fn take_redraw_thread(&mut self) -> Option<std::thread::JoinHandle<()>> {
+        if let Err(e) = self.redraw_tx.send(RedrawCommand::Stop) {
+            log::error!("DrawingWindow::take_redraw_thread: failed to send Stop: {e:?}");
+        }
+        self.redraw_thread.take()
+    }
+
+    pub fn hide(&self) {
+        self.window.set_visible(false);
+    }
+
+    fn set_default_cursor(&self) {
+        #[cfg(target_os = "macos")]
+        {
+            use objc2_app_kit::NSCursor;
+            NSCursor::arrowCursor().set();
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            self.window.set_cursor(winit::window::Cursor::Icon(
+                winit::window::CursorIcon::Default,
+            ));
+        }
+    }
+
+    fn set_pencil_cursor(&mut self, reset_counter: bool) {
+        if reset_counter {
+            self.pencil_cursor_counter = 20;
+        }
+        #[cfg(target_os = "macos")]
+        {
+            self.ns_cursor_pencil.set();
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            self.window.set_cursor(winit::window::Cursor::Custom(
+                self.custom_cursor_pencil.clone(),
+            ));
+        }
+    }
+
+    fn view<'a>(
+        participants: &'a ParticipantsManager,
+    ) -> iced::Element<'a, DrawingMessage, Theme, iced::Renderer> {
+        let canvas_overlay = canvas(DrawingOverlay { participants })
+            .width(Length::Fill)
+            .height(Length::Fill);
+
+        container(canvas_overlay)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .style(|_theme: &Theme| container::Style {
+                background: Some(Background::Color(Color::TRANSPARENT)),
+                ..Default::default()
+            })
+            .into()
+    }
+
+    pub fn handle_window_event(&mut self, event: WindowEvent) -> Option<DrawingWindowInputEvent> {
+        let mut input_event = None;
+        let scale_factor = self.window.scale_factor() as f32;
+
+        match &event {
+            WindowEvent::CursorMoved { position, .. } => {
+                let physical_size = self.window.inner_size();
+                let pct_x = (position.x / physical_size.width as f64).clamp(0.0, 1.0);
+                let pct_y = (position.y / physical_size.height as f64).clamp(0.0, 1.0);
+                self.last_cursor_position = Some((pct_x, pct_y));
+
+                if self.left_mouse_pressed {
+                    self.participants_manager.draw_add_point(
+                        drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                        Position { x: pct_x, y: pct_y },
+                    );
+                    input_event =
+                        Some(DrawingWindowInputEvent::DrawAddPoint { x: pct_x, y: pct_y });
+                    self.signal_activity();
+                }
+            }
+            WindowEvent::CursorEntered { .. } => {
+                log::info!("drawing_window: cursor entered");
+                self.set_pencil_cursor(true);
+            }
+            WindowEvent::CursorLeft { .. } => {
+                if self.left_mouse_pressed {
+                    if let Some((lx, ly)) = self.last_cursor_position {
+                        self.participants_manager.draw_end(
+                            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                            Position { x: lx, y: ly },
+                        );
+                        input_event = Some(DrawingWindowInputEvent::DrawEnd { x: lx, y: ly });
+                    }
+                    self.left_mouse_pressed = false;
+                    self.signal_activity();
+                }
+                self.set_default_cursor();
+            }
+            WindowEvent::Focused(true) => {
+                self.set_pencil_cursor(true);
+            }
+            WindowEvent::Focused(false) => {
+                if self.left_mouse_pressed {
+                    if let Some((lx, ly)) = self.last_cursor_position {
+                        self.participants_manager.draw_end(
+                            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                            Position { x: lx, y: ly },
+                        );
+                        input_event = Some(DrawingWindowInputEvent::DrawEnd { x: lx, y: ly });
+                    }
+                    self.left_mouse_pressed = false;
+                    self.signal_activity();
+                }
+                self.set_default_cursor();
+            }
+            WindowEvent::MouseInput { state, button, .. } => {
+                let (pct_x, pct_y) = match &self.cursor {
+                    mouse::Cursor::Available(pos) => {
+                        let physical_size = self.window.inner_size();
+                        let logical_width = physical_size.width as f64 / scale_factor as f64;
+                        let logical_height = physical_size.height as f64 / scale_factor as f64;
+                        (
+                            (pos.x as f64 / logical_width).clamp(0.0, 1.0),
+                            (pos.y as f64 / logical_height).clamp(0.0, 1.0),
+                        )
+                    }
+                    _ => (0.0, 0.0),
+                };
+
+                if *button == winit::event::MouseButton::Left {
+                    if state.is_pressed() {
+                        self.current_path_id += 1;
+                        self.left_mouse_pressed = true;
+                        self.participants_manager.draw_start(
+                            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                            Position { x: pct_x, y: pct_y },
+                            self.current_path_id,
+                        );
+                        input_event = Some(DrawingWindowInputEvent::DrawStart {
+                            x: pct_x,
+                            y: pct_y,
+                            path_id: self.current_path_id,
+                        });
+                        self.signal_activity();
+                    } else {
+                        self.left_mouse_pressed = false;
+                        self.participants_manager.draw_end(
+                            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                            Position { x: pct_x, y: pct_y },
+                        );
+                        input_event = Some(DrawingWindowInputEvent::DrawEnd { x: pct_x, y: pct_y });
+                        self.signal_activity();
+                    }
+                } else if *button == winit::event::MouseButton::Right
+                    && state.is_pressed()
+                    && self.draw_persist
+                {
+                    self.participants_manager
+                        .draw_clear_all_paths(drawing_helpers::LOCAL_PARTICIPANT_IDENTITY);
+                    input_event = Some(DrawingWindowInputEvent::DrawClearAllPaths);
+                    self.signal_activity();
+                }
+            }
+            WindowEvent::KeyboardInput { event, .. } => {
+                if event.state.is_pressed() {
+                    if let Key::Named(NamedKey::Escape) = event.logical_key {
+                        input_event = Some(DrawingWindowInputEvent::Escape);
+                    }
+                }
+            }
+            WindowEvent::Resized(new_size) => {
+                if new_size.width > 0 && new_size.height > 0 {
+                    self.surface.configure(
+                        &self.device,
+                        &wgpu::SurfaceConfiguration {
+                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                            format: self.format,
+                            width: new_size.width,
+                            height: new_size.height,
+                            present_mode: wgpu::PresentMode::AutoVsync,
+                            alpha_mode: self.alpha_mode,
+                            view_formats: vec![],
+                            desired_maximum_frame_latency: 2,
+                        },
+                    );
+                    self.viewport = Viewport::with_physical_size(
+                        Size::new(new_size.width, new_size.height),
+                        self.window.scale_factor() as f32,
+                    );
+                    self.signal_activity();
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                let cleared = self.redraw();
+                if !cleared.is_empty() {
+                    input_event = Some(DrawingWindowInputEvent::DrawClearPaths(cleared));
+                }
+            }
+            WindowEvent::CloseRequested => {
+                self.window.set_visible(false);
+            }
+            _ => {}
+        }
+
+        if !matches!(event, WindowEvent::RedrawRequested) {
+            if let Some(iced_event) = conversion::window_event(
+                event.clone(),
+                self.window.scale_factor() as f32,
+                self.modifiers,
+            ) {
+                if let Event::Mouse(mouse_event) = iced_event {
+                    self.cursor = match mouse_event {
+                        iced::mouse::Event::CursorMoved { position } => {
+                            mouse::Cursor::Available(position)
+                        }
+                        iced::mouse::Event::CursorLeft => mouse::Cursor::Unavailable,
+                        _ => self.cursor,
+                    };
+                }
+
+                let mut messages: Vec<DrawingMessage> = Vec::new();
+
+                let cache = self.cache.take().unwrap_or_default();
+                let mut interface = UserInterface::build(
+                    Self::view(&self.participants_manager),
+                    self.viewport.logical_size(),
+                    cache,
+                    &mut self.renderer,
+                );
+
+                let iced_event = conversion::window_event(
+                    event.clone(),
+                    self.window.scale_factor() as f32,
+                    self.modifiers,
+                );
+                if let Some(ev) = iced_event {
+                    let (_, _) = interface.update(
+                        &[ev],
+                        self.cursor,
+                        &mut self.renderer,
+                        &mut self.clipboard,
+                        &mut messages,
+                    );
+                }
+
+                self.cache = Some(interface.into_cache());
+            }
+        }
+
+        if let WindowEvent::ModifiersChanged(new_modifiers) = event {
+            self.modifiers = new_modifiers.state();
+        }
+
+        input_event
+    }
+
+    fn redraw(&mut self) -> Vec<u64> {
+        if self.pencil_cursor_counter > 0 {
+            self.set_pencil_cursor(false);
+            self.pencil_cursor_counter -= 1;
+        }
+
+        self.participants_manager.hide_inactive_cursors();
+
+        let cleared = self.participants_manager.update_auto_clear();
+
+        let output = match self.surface.get_current_texture() {
+            Ok(output) => output,
+            Err(e) => {
+                log::error!("DrawingWindow::redraw: failed to get texture: {e:?}");
+                return cleared;
+            }
+        };
+
+        let view = output
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+        let cache = self.cache.take().unwrap_or_default();
+        let mut interface = UserInterface::build(
+            Self::view(&self.participants_manager),
+            self.viewport.logical_size(),
+            cache,
+            &mut self.renderer,
+        );
+
+        let _ = interface.update(
+            &[Event::Window(
+                window::Event::RedrawRequested(Instant::now()),
+            )],
+            self.cursor,
+            &mut self.renderer,
+            &mut self.clipboard,
+            &mut Vec::new(),
+        );
+
+        interface.draw(
+            &mut self.renderer,
+            &Theme::Dark,
+            &Style {
+                text_color: Color::WHITE,
+            },
+            self.cursor,
+        );
+        self.cache = Some(interface.into_cache());
+
+        let wgpu_renderer = match &mut self.renderer {
+            iced::Renderer::Primary(r) => r,
+            _ => unreachable!(),
+        };
+        wgpu_renderer.present(
+            Some(Color::TRANSPARENT),
+            output.texture.format(),
+            &view,
+            &self.viewport,
+        );
+
+        self.window.pre_present_notify();
+        output.present();
+
+        cleared
+    }
+}

--- a/core/src/window/drawing_window.rs
+++ b/core/src/window/drawing_window.rs
@@ -10,8 +10,8 @@ use iced_winit::core::{window, Event, Size};
 use iced_winit::runtime::user_interface::Cache;
 use iced_winit::runtime::UserInterface;
 use iced_winit::{conversion, Clipboard};
-use winit::event::WindowEvent;
 use winit::dpi::LogicalSize;
+use winit::event::WindowEvent;
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::{Key, ModifiersState, NamedKey};
 use winit::window::{Window, WindowAttributes, WindowId};
@@ -32,10 +32,7 @@ pub fn drawing_window_attributes() -> WindowAttributes {
         .with_decorations(false)
         .with_transparent(true)
         .with_content_protected(true)
-        .with_inner_size(LogicalSize::new(
-            1.0,
-            1.0,
-        ))
+        .with_inner_size(LogicalSize::new(1.0, 1.0))
         .with_window_level(WindowLevel::AlwaysOnTop);
 
     #[cfg(target_os = "macos")]

--- a/core/src/window/screensharing_window.rs
+++ b/core/src/window/screensharing_window.rs
@@ -14,13 +14,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
 
+use iced::mouse;
 use iced::widget::{canvas, column, container, row, shader, stack, text, Space};
 use iced::{
     gradient, Alignment, Background, Border, Color, Length, Padding, Pixels, Radians, Rectangle,
     Shadow, Vector,
 };
 use iced_core::clipboard::Kind;
-use iced_wgpu::core::mouse;
 use iced_wgpu::graphics::Viewport;
 use iced_winit::core::renderer::Style;
 use iced_winit::core::time::Instant;
@@ -32,14 +32,16 @@ use winit::event::WindowEvent;
 use winit::event_loop::ActiveEventLoop;
 use winit::keyboard::{Key, ModifiersState};
 #[cfg(not(target_os = "macos"))]
-use winit::window::{CursorIcon, CustomCursor};
+use winit::window::CursorIcon;
 use winit::window::{Window, WindowAttributes, WindowId};
 
 use thiserror::Error;
 
-use fontdb::Database;
-use resvg::{tiny_skia, usvg};
-
+use super::aspect_ratio::{
+    calculate_max_window_size, default_window_size, min_window_size, AspectRatioEnforcer,
+    WindowConstant,
+};
+use super::drawing_helpers;
 use crate::components::dropdown::{dropdown_overlay, dropdown_trigger_button, DropdownItemDef};
 use crate::components::fonts::{self as fonts_mod, GEIST_MEDIUM, GEIST_REGULAR};
 use crate::components::segmented_control::{
@@ -52,11 +54,6 @@ use crate::graphics::yuv_renderer::YuvVideoProgram;
 use crate::utils::clock;
 use crate::utils::geometry::{Extent, Position};
 use crate::windows::colors::ColorToken;
-
-use super::aspect_ratio::{
-    calculate_max_window_size, default_window_size, min_window_size, AspectRatioEnforcer,
-    WindowConstant,
-};
 
 pub fn screensharing_window_attributes() -> WindowAttributes {
     let (init_w, init_h) = default_window_size();
@@ -280,8 +277,6 @@ fn spawn_redraw_thread(
 }
 /// Dedicated renderer ID for the screensharing stream in YUV pipeline caches.
 const SCREENSHARE_STREAM_ID: u64 = u64::MAX;
-/// Identity used for the local participant's drawing/cursor state.
-const LOCAL_PARTICIPANT_IDENTITY: &str = "local";
 
 const ICON_COG: &[u8] = include_bytes!("../../resources/icons/cog.svg");
 const ICON_PENCIL_SVG: &[u8] = include_bytes!("../../resources/icons/pencil.svg");
@@ -290,12 +285,6 @@ const ICON_PENCIL_SVG: &[u8] = include_bytes!("../../resources/icons/pencil.svg"
 const ICON_REMOTE_CONTROL: char = '\u{F107}';
 const ICON_PEN: char = '\u{F109}';
 const ICON_CLICK_POINTER: char = '\u{F108}';
-const CURSOR_ICON_POINTER: &[u8] =
-    include_bytes!("../../resources/icons/local-participant-cursor.svg");
-const CURSOR_ICON_PENCIL: &[u8] =
-    include_bytes!("../../resources/icons/local-participant-pencil.svg");
-const CURSOR_ICON_POINT: &[u8] =
-    include_bytes!("../../resources/icons/local-participant-pointer.svg");
 
 // ── Segmented control buttons ────────────────────────────────────────────────
 const SEGMENTED_BUTTONS: &[SegmentedButton] = &[
@@ -420,131 +409,6 @@ impl Default for ScreensharingState {
             last_click_y: 0.0,
             sharer_name: "Screen".to_string(),
         }
-    }
-}
-
-/// Canvas overlay that draws remote participant cursors and drawing strokes
-/// on top of the video content.
-struct ParticipantOverlay<'a> {
-    participants: &'a ParticipantsManager,
-    click_animation_renderer: &'a ClickAnimationRenderer,
-}
-
-impl<'a, Message> canvas::Program<Message> for ParticipantOverlay<'a> {
-    type State = ();
-
-    fn draw(
-        &self,
-        _state: &(),
-        renderer: &iced::Renderer,
-        _theme: &Theme,
-        bounds: Rectangle,
-        _cursor: mouse::Cursor,
-    ) -> Vec<canvas::Geometry> {
-        let translate = |pos: Position| -> Position {
-            Position {
-                x: pos.x * bounds.width as f64,
-                y: pos.y * bounds.height as f64,
-            }
-        };
-        let mut geometries = self.participants.draw(renderer, bounds, &translate);
-        geometries.push(
-            self.click_animation_renderer
-                .draw(renderer, bounds, &translate),
-        );
-        geometries
-    }
-}
-
-/// Rasterize SVG bytes to straight-alpha RGBA at the given pixel size.
-fn rasterize_svg_to_rgba(svg_bytes: &[u8], px_size: u32) -> (Vec<u8>, u32, u32) {
-    let fontdb = std::sync::Arc::new(Database::new());
-    let usvg_options = usvg::Options {
-        fontdb,
-        ..Default::default()
-    };
-    let tree = usvg::Tree::from_data(svg_bytes, &usvg_options)
-        .expect("rasterize_svg_to_rgba: failed to parse cursor SVG");
-    let svg_size = tree.size();
-    let max_dim = svg_size.width().max(svg_size.height());
-    let scale = if max_dim > 0.0 {
-        px_size as f32 / max_dim
-    } else {
-        1.0
-    };
-    let w = (svg_size.width() * scale).ceil().max(1.0) as u32;
-    let h = (svg_size.height() * scale).ceil().max(1.0) as u32;
-    let mut pixmap = tiny_skia::Pixmap::new(w, h).expect("rasterize_svg_to_rgba: pixmap");
-    resvg::render(
-        &tree,
-        tiny_skia::Transform::from_scale(scale, scale),
-        &mut pixmap.as_mut(),
-    );
-    // tiny_skia gives premultiplied RGBA — convert to straight alpha.
-    let mut rgba = pixmap.data().to_vec();
-    for px in rgba.chunks_exact_mut(4) {
-        let a = px[3] as f32;
-        if a > 0.0 && a < 255.0 {
-            let inv = 255.0 / a;
-            px[0] = (px[0] as f32 * inv).round().min(255.0) as u8;
-            px[1] = (px[1] as f32 * inv).round().min(255.0) as u8;
-            px[2] = (px[2] as f32 * inv).round().min(255.0) as u8;
-        }
-    }
-    (rgba, w, h)
-}
-
-/// Create an `NSCursor` from RGBA pixel data, with `logical_size` in points
-/// and `pixel_size` actual pixels.  The hotspot is given in **point** coords.
-#[cfg(target_os = "macos")]
-fn create_macos_cursor(
-    rgba: &[u8],
-    pixel_w: u32,
-    pixel_h: u32,
-    logical_w: f64,
-    logical_h: f64,
-    hotspot_x: f64,
-    hotspot_y: f64,
-) -> objc2::rc::Retained<objc2_app_kit::NSCursor> {
-    use objc2::rc::Retained;
-    use objc2::AnyThread;
-    use objc2_app_kit::{NSBitmapImageRep, NSCursor, NSImage, NSImageRep};
-    use objc2_foundation::{NSPoint, NSSize};
-
-    unsafe {
-        // Build NSBitmapImageRep with an empty buffer that we'll fill.
-        let planes_ptr: *mut *mut u8 = std::ptr::null_mut();
-        let rep: Retained<NSBitmapImageRep> = objc2::msg_send![
-            NSBitmapImageRep::alloc(),
-            initWithBitmapDataPlanes: planes_ptr,
-            pixelsWide: pixel_w as isize,
-            pixelsHigh: pixel_h as isize,
-            bitsPerSample: 8_isize,
-            samplesPerPixel: 4_isize,
-            hasAlpha: true,
-            isPlanar: false,
-            colorSpaceName: objc2_app_kit::NSDeviceRGBColorSpace,
-            bytesPerRow: (pixel_w * 4) as isize,
-            bitsPerPixel: 32_isize
-        ];
-
-        // Copy pixel data into the rep's buffer.
-        let bitmap_data: *mut u8 = objc2::msg_send![&rep, bitmapData];
-        std::ptr::copy_nonoverlapping(rgba.as_ptr(), bitmap_data, rgba.len());
-
-        // Wrap in NSImage and set the logical (point) size.
-        let image = NSImage::new();
-        let rep_as_imagerep: &NSImageRep =
-            &*((&rep as &NSBitmapImageRep) as *const NSBitmapImageRep as *const NSImageRep);
-        image.addRepresentation(rep_as_imagerep);
-        image.setSize(NSSize::new(logical_w, logical_h));
-
-        // Create cursor with hotspot in point coordinates.
-        NSCursor::initWithImage_hotSpot(
-            NSCursor::alloc(),
-            &image,
-            NSPoint::new(hotspot_x, hotspot_y),
-        )
     }
 }
 
@@ -676,67 +540,65 @@ impl ScreensharingWindow {
         let aspect_ratio_enforcer = AspectRatioEnforcer::new(&window);
 
         // Create custom cursors for the participant area.
-        // Logical size: 30×30 points (matching the SVG viewBox).
-        const CURSOR_LOGICAL_SIZE: f64 = 30.0;
-
-        // TODO(@konsalex): Extract in core init, to avoid re-rasterizing the cursors
-        // on every window creation.
-        // On macOS, rasterize at 4× the logical size for maximum crispness,
-        // then create native NSCursors with the point size set to 30×30.
         #[cfg(target_os = "macos")]
         let (ns_cursor_pointer, ns_cursor_pencil, ns_cursor_point) = {
-            let px = (CURSOR_LOGICAL_SIZE * 4.0).round() as u32;
-            let (pointer_rgba, pw, ph) = rasterize_svg_to_rgba(CURSOR_ICON_POINTER, px);
-            let (pencil_rgba, ew, eh) = rasterize_svg_to_rgba(CURSOR_ICON_PENCIL, px);
-            let (point_rgba, pt_w, pt_h) = rasterize_svg_to_rgba(CURSOR_ICON_POINT, px);
-            let pointer = create_macos_cursor(
+            let px = (drawing_helpers::CURSOR_LOGICAL_SIZE * 4.0).round() as u32;
+            let (pointer_rgba, pw, ph) =
+                drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_POINTER, px);
+            let (pencil_rgba, ew, eh) =
+                drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_PENCIL, px);
+            let (point_rgba, pt_w, pt_h) =
+                drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_POINT, px);
+            let pointer = drawing_helpers::create_macos_cursor(
                 &pointer_rgba,
                 pw,
                 ph,
-                CURSOR_LOGICAL_SIZE,
-                CURSOR_LOGICAL_SIZE,
+                drawing_helpers::CURSOR_LOGICAL_SIZE,
+                drawing_helpers::CURSOR_LOGICAL_SIZE,
                 3.0,
                 2.0,
             );
-            let pencil = create_macos_cursor(
+            let pencil = drawing_helpers::create_macos_cursor(
                 &pencil_rgba,
                 ew,
                 eh,
-                CURSOR_LOGICAL_SIZE,
-                CURSOR_LOGICAL_SIZE,
+                drawing_helpers::CURSOR_LOGICAL_SIZE,
+                drawing_helpers::CURSOR_LOGICAL_SIZE,
                 2.0,
                 29.0,
             );
-            let point = create_macos_cursor(
+            let point = drawing_helpers::create_macos_cursor(
                 &point_rgba,
                 pt_w,
                 pt_h,
-                CURSOR_LOGICAL_SIZE,
-                CURSOR_LOGICAL_SIZE,
+                drawing_helpers::CURSOR_LOGICAL_SIZE,
+                drawing_helpers::CURSOR_LOGICAL_SIZE,
                 2.0,
                 4.0,
             );
             (pointer, pencil, point)
         };
 
-        // On non-macOS platforms, fall back to winit CustomCursor at 30px.
         #[cfg(not(target_os = "macos"))]
         let (custom_cursor_pointer, custom_cursor_pencil, custom_cursor_point) = {
             let point_cursor_hotspot = (2.0, 4.0);
-            let px = CURSOR_LOGICAL_SIZE as u32;
-            let (pointer_rgba, pw, ph) = rasterize_svg_to_rgba(CURSOR_ICON_POINTER, px);
-            let (pencil_rgba, ew, eh) = rasterize_svg_to_rgba(CURSOR_ICON_PENCIL, px);
-            let (point_rgba, pt_w, pt_h) = rasterize_svg_to_rgba(CURSOR_ICON_POINT, px);
+            let px = drawing_helpers::CURSOR_LOGICAL_SIZE as u32;
+            let (pointer_rgba, pw, ph) =
+                drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_POINTER, px);
+            let (pencil_rgba, ew, eh) =
+                drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_PENCIL, px);
+            let (point_rgba, pt_w, pt_h) =
+                drawing_helpers::rasterize_svg_to_rgba(drawing_helpers::CURSOR_ICON_POINT, px);
             let pointer = event_loop.create_custom_cursor(
-                CustomCursor::from_rgba(pointer_rgba, pw as u16, ph as u16, 3, 2)
+                winit::window::CustomCursor::from_rgba(pointer_rgba, pw as u16, ph as u16, 3, 2)
                     .expect("create pointer cursor"),
             );
             let pencil = event_loop.create_custom_cursor(
-                CustomCursor::from_rgba(pencil_rgba, ew as u16, eh as u16, 2, 29)
+                winit::window::CustomCursor::from_rgba(pencil_rgba, ew as u16, eh as u16, 2, 29)
                     .expect("create pencil cursor"),
             );
             let point = event_loop.create_custom_cursor(
-                CustomCursor::from_rgba(
+                winit::window::CustomCursor::from_rgba(
                     point_rgba,
                     pt_w as u16,
                     pt_h as u16,
@@ -761,8 +623,8 @@ impl ScreensharingWindow {
         }
         // Always add a local participant for the controller's own drawing/cursor state.
         if let Err(e) = participants_manager.add_participant(
-            LOCAL_PARTICIPANT_IDENTITY.to_string(),
-            LOCAL_PARTICIPANT_IDENTITY,
+            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY.to_string(),
+            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
             true,
             crate::room_service::DrawingMode::Disabled,
         ) {
@@ -809,7 +671,8 @@ impl ScreensharingWindow {
                         crate::room_service::DrawingMode::Disabled,
                     ),
                 };
-                participants_manager.set_drawing_mode(LOCAL_PARTICIPANT_IDENTITY, initial_mode);
+                participants_manager
+                    .set_drawing_mode(drawing_helpers::LOCAL_PARTICIPANT_IDENTITY, initial_mode);
                 ScreensharingState {
                     sharer_name: sharer_first_name,
                     draw_persist,
@@ -1099,7 +962,7 @@ impl ScreensharingWindow {
 
                     if self.state.active_tab == "draw" && self.state.left_mouse_pressed {
                         self.participants_manager.draw_add_point(
-                            LOCAL_PARTICIPANT_IDENTITY,
+                            drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
                             crate::utils::geometry::Position { x: pct_x, y: pct_y },
                         );
                         input_event =
@@ -1120,7 +983,7 @@ impl ScreensharingWindow {
                     if self.state.active_tab == "draw" && self.state.left_mouse_pressed {
                         if let Some((lx, ly)) = self.state.last_draw_cursor {
                             self.participants_manager.draw_end(
-                                LOCAL_PARTICIPANT_IDENTITY,
+                                drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
                                 crate::utils::geometry::Position { x: lx, y: ly },
                             );
                             input_event = Some(ScreenShareInputEvent::DrawEnd { x: lx, y: ly });
@@ -1138,7 +1001,7 @@ impl ScreensharingWindow {
                     if self.state.active_tab == "draw" && self.state.left_mouse_pressed {
                         if let Some((lx, ly)) = self.state.last_draw_cursor {
                             self.participants_manager.draw_end(
-                                LOCAL_PARTICIPANT_IDENTITY,
+                                drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
                                 crate::utils::geometry::Position { x: lx, y: ly },
                             );
                             input_event = Some(ScreenShareInputEvent::DrawEnd { x: lx, y: ly });
@@ -1158,7 +1021,7 @@ impl ScreensharingWindow {
                     if self.state.active_tab == "draw" && self.state.left_mouse_pressed {
                         if let Some((lx, ly)) = self.state.last_draw_cursor {
                             self.participants_manager.draw_end(
-                                LOCAL_PARTICIPANT_IDENTITY,
+                                drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
                                 crate::utils::geometry::Position { x: lx, y: ly },
                             );
                             input_event = Some(ScreenShareInputEvent::DrawEnd { x: lx, y: ly });
@@ -1192,7 +1055,7 @@ impl ScreensharingWindow {
                                     self.state.current_path_id += 1;
                                     self.state.left_mouse_pressed = true;
                                     self.participants_manager.draw_start(
-                                        LOCAL_PARTICIPANT_IDENTITY,
+                                        drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
                                         crate::utils::geometry::Position { x: pct_x, y: pct_y },
                                         self.state.current_path_id,
                                     );
@@ -1204,7 +1067,7 @@ impl ScreensharingWindow {
                                 } else {
                                     self.state.left_mouse_pressed = false;
                                     self.participants_manager.draw_end(
-                                        LOCAL_PARTICIPANT_IDENTITY,
+                                        drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
                                         crate::utils::geometry::Position { x: pct_x, y: pct_y },
                                     );
                                     input_event =
@@ -1213,8 +1076,9 @@ impl ScreensharingWindow {
                             }
                             winit::event::MouseButton::Right => {
                                 if down && self.state.draw_persist {
-                                    self.participants_manager
-                                        .draw_clear_all_paths(LOCAL_PARTICIPANT_IDENTITY);
+                                    self.participants_manager.draw_clear_all_paths(
+                                        drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                                    );
                                     input_event = Some(ScreenShareInputEvent::DrawClearAllPaths);
                                 }
                             }
@@ -1506,11 +1370,14 @@ impl ScreensharingWindow {
                             if mode == crate::room_service::DrawingMode::Disabled
                                 || mode == crate::room_service::DrawingMode::ClickAnimation
                             {
-                                self.participants_manager
-                                    .draw_clear_all_paths(LOCAL_PARTICIPANT_IDENTITY);
+                                self.participants_manager.draw_clear_all_paths(
+                                    drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                                );
                             }
-                            self.participants_manager
-                                .set_drawing_mode(LOCAL_PARTICIPANT_IDENTITY, mode.clone());
+                            self.participants_manager.set_drawing_mode(
+                                drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                                mode.clone(),
+                            );
                             self.state.left_mouse_pressed = false;
                             input_event = Some(ScreenShareInputEvent::DrawingModeChanged(mode));
                         }
@@ -1519,8 +1386,10 @@ impl ScreensharingWindow {
                             let mode = crate::room_service::DrawingMode::Draw(
                                 crate::room_service::DrawSettings { permanent },
                             );
-                            self.participants_manager
-                                .set_drawing_mode(LOCAL_PARTICIPANT_IDENTITY, mode.clone());
+                            self.participants_manager.set_drawing_mode(
+                                drawing_helpers::LOCAL_PARTICIPANT_IDENTITY,
+                                mode.clone(),
+                            );
                             input_event = Some(ScreenShareInputEvent::DrawingModeChanged(mode));
                         }
                         _ => {}
@@ -1748,9 +1617,9 @@ impl ScreensharingWindow {
             };
 
         let canvas_overlay: iced::Element<'a, ScreensharingMessage, Theme, iced::Renderer> =
-            canvas(ParticipantOverlay {
+            canvas(drawing_helpers::ParticipantOverlay {
                 participants,
-                click_animation_renderer,
+                click_animation_renderer: Some(click_animation_renderer),
             })
             .width(Length::Fill)
             .height(Length::Fill)

--- a/core/src/window_manager.rs
+++ b/core/src/window_manager.rs
@@ -223,6 +223,13 @@ impl WindowManager {
         }
     }
 
+    pub fn active_window_position(&self) -> Option<LogicalPosition<f64>> {
+        let active_id = self.active_monitor_id.as_ref()?;
+        let entry = self.windows.iter().find(|e| &e.monitor_id == active_id)?;
+        let pos = entry.window.outer_position().ok()?;
+        Some(pos.to_logical(entry.window.scale_factor()))
+    }
+
     pub fn is_active_window(&self, window_id: winit::window::WindowId) -> bool {
         self.active_monitor_id.as_ref().is_some_and(|active_id| {
             self.windows

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -86,6 +86,9 @@ pub struct AppData {
     /// Whether noise cancellation is enabled (synced with core process).
     pub noise_cancellation_enabled: bool,
 
+    /// Whether drawing mode is currently enabled (runtime state).
+    pub drawing_enabled: bool,
+
     /// macOS app activation observer — keeps the NSNotificationCenter observer alive.
     #[cfg(target_os = "macos")]
     pub activation_observer: Option<app_activation::AppActivationObserver>,
@@ -121,6 +124,7 @@ impl AppData {
             activation_policy_regular: false,
             suppress_hide_on_call_end,
             noise_cancellation_enabled: true,
+            drawing_enabled: false,
             #[cfg(target_os = "macos")]
             sleep_prevention: sleep_prevention::SleepPrevention::new(),
         }

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -451,24 +451,40 @@ fn set_drawing_hint_shown(app: tauri::AppHandle, shown: bool) {
 }
 
 #[tauri::command(async)]
-fn enable_drawing(app: tauri::AppHandle, permanent: bool) {
-    log::info!("enable_drawing: permanent={permanent}");
+fn get_drawing_enabled(app: tauri::AppHandle) -> bool {
+    log::info!("get_drawing_enabled");
     let data = app.state::<Mutex<AppData>>();
     let data = data.lock().unwrap();
+    data.drawing_enabled
+}
+
+#[tauri::command(async)]
+fn set_drawing_enabled(app: tauri::AppHandle, enabled: bool, permanent: bool) {
+    log::info!("set_drawing_enabled: enabled={enabled} permanent={permanent}");
+    let data = app.state::<Mutex<AppData>>();
+    let mut data = data.lock().unwrap();
+
+    if data.drawing_enabled == enabled {
+        return;
+    }
+
+    data.drawing_enabled = enabled;
+
     if let Err(e) = data
         .sender
         .send(Message::DrawingEnabled(DrawingEnabled { permanent }))
     {
-        log::error!("enable_drawing: failed to send message: {e:?}");
+        log::error!("set_drawing_enabled: failed to send message: {e:?}");
     }
     drop(data);
 
-    // Hide main window
-    if let Some(window) = app.get_webview_window("main") {
-        #[cfg(target_os = "macos")]
-        let _ = window.hide();
-        #[cfg(target_os = "windows")]
-        let _ = window.minimize();
+    if enabled {
+        if let Some(window) = app.get_webview_window("main") {
+            #[cfg(target_os = "macos")]
+            let _ = window.hide();
+            #[cfg(target_os = "windows")]
+            let _ = window.minimize();
+        }
     }
 }
 
@@ -1511,7 +1527,8 @@ fn main() {
             set_sharer_draw_persist,
             get_drawing_hint_shown,
             set_drawing_hint_shown,
-            enable_drawing,
+            get_drawing_enabled,
+            set_drawing_enabled,
             minimize_main_window,
             set_livekit_url,
             get_livekit_url,

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -430,6 +430,12 @@ fn set_sharer_draw_persist(app: tauri::AppHandle, persist: bool) {
     let data = app.state::<Mutex<AppData>>();
     let mut data = data.lock().unwrap();
     data.app_state.set_sharer_draw_persist(persist);
+
+    if data.drawing_enabled {
+        if let Err(e) = data.sender.send(Message::SharerDrawPersistChanged(persist)) {
+            log::error!("set_sharer_draw_persist: failed to send message: {e:?}");
+        }
+    }
 }
 
 #[tauri::command(async)]

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -496,6 +496,18 @@ fn set_drawing_enabled(app: tauri::AppHandle, enabled: bool, permanent: bool) {
 }
 
 #[tauri::command(async)]
+fn quit_app(app: tauri::AppHandle) {
+    log::info!("quit_app");
+    let data = app.state::<Mutex<AppData>>();
+    let data = data.lock().unwrap();
+    if let Err(e) = data.sender.send(Message::CallEnd) {
+        log::error!("quit_app: failed to send CallEnd: {e:?}");
+    }
+    drop(data);
+    app.exit(0);
+}
+
+#[tauri::command(async)]
 fn minimize_main_window(app: tauri::AppHandle) {
     log::info!("minimize_main_window");
     if let Some(window) = app.get_webview_window("main") {
@@ -1579,6 +1591,7 @@ fn main() {
             toggle_call_sleep_prevention,
             bring_windows_to_front,
             open_stats_window,
+            quit_app,
         ])
         .build(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -485,8 +485,10 @@ fn set_drawing_enabled(app: tauri::AppHandle, enabled: bool, permanent: bool) {
     data.drawing_enabled = enabled;
     drop(data);
 
-    if enabled {
-        if let Some(window) = app.get_webview_window("main") {
+    if let Some(window) = app.get_webview_window("main") {
+        #[cfg(not(target_os = "macos"))]
+        let _ = window.set_always_on_top(enabled);
+        if enabled {
             #[cfg(target_os = "macos")]
             let _ = window.hide();
             #[cfg(target_os = "windows")]
@@ -1148,6 +1150,10 @@ fn forward_core_events(events_rx: std_mpsc::Receiver<Message>, app: tauri::AppHa
                 let mut data = data.lock().unwrap();
                 data.drawing_enabled = false;
                 drop(data);
+                #[cfg(not(target_os = "macos"))]
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.set_always_on_top(false);
+                }
                 if let Err(e) = app.emit("core_drawing_disabled", &()) {
                     log::error!("forward_core_events: failed to emit core_drawing_disabled: {e:?}");
                 }

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -474,14 +474,15 @@ fn set_drawing_enabled(app: tauri::AppHandle, enabled: bool, permanent: bool) {
         return;
     }
 
-    data.drawing_enabled = enabled;
-
     if let Err(e) = data
         .sender
         .send(Message::DrawingEnabled(DrawingEnabled { permanent }))
     {
         log::error!("set_drawing_enabled: failed to send message: {e:?}");
+        return;
     }
+
+    data.drawing_enabled = enabled;
     drop(data);
 
     if enabled {
@@ -1127,6 +1128,16 @@ fn forward_core_events(events_rx: std_mpsc::Receiver<Message>, app: tauri::AppHa
             Message::MicrophoneAudioLevel(level) => {
                 if let Err(e) = app.emit("core_mic_audio_level", &level) {
                     log::error!("forward_core_events: failed to emit mic audio level: {e:?}");
+                }
+            }
+            Message::DrawingDisabled => {
+                log::info!("forward_core_events: drawing disabled");
+                let data = app.state::<Mutex<AppData>>();
+                let mut data = data.lock().unwrap();
+                data.drawing_enabled = false;
+                drop(data);
+                if let Err(e) = app.emit("core_drawing_disabled", &()) {
+                    log::error!("forward_core_events: failed to emit core_drawing_disabled: {e:?}");
                 }
             }
             other => {

--- a/tauri/src/components/sidebar/Sidebar.tsx
+++ b/tauri/src/components/sidebar/Sidebar.tsx
@@ -268,6 +268,7 @@ export const Sidebar = () => {
                 >
                   Sign-out
                 </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => invoke("quit_app")}>Quit</DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <div className="muted text-slate-500 px-2 py-0.5">App version: {appVersion}</div>
               </DropdownMenuContent>

--- a/tauri/src/components/ui/call-center.tsx
+++ b/tauri/src/components/ui/call-center.tsx
@@ -1,6 +1,6 @@
 import { formatDistanceToNow } from "date-fns";
 import { LuMicOff, LuVideo, LuVideoOff, LuScreenShare, LuScreenShareOff, LuWifiOff } from "react-icons/lu";
-import { PiScribbleLoopBold } from "react-icons/pi";
+import { PiScribbleLoopBold, PiCursorBold } from "react-icons/pi";
 import useStore, { CallState, ParticipantRole } from "@/store/store";
 import { Separator } from "@/components/ui/separator";
 import { ToggleIconButton } from "@/components/ui/toggle-icon-button";
@@ -240,21 +240,26 @@ export function CallCenter() {
 
 function DrawingEnableButton() {
   const [drawingPermanent, setDrawingPermanent] = useState(false);
+  const [drawingEnabled, setDrawingEnabled] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [hintShown, setHintShown] = useState(false);
 
   useEffect(() => {
-    const loadPreference = async () => {
+    const loadPreferences = async () => {
       try {
-        const permanent = await tauriUtils.getSharerDrawPersist();
+        const [permanent, enabled, shown] = await Promise.all([
+          tauriUtils.getSharerDrawPersist(),
+          tauriUtils.getDrawingEnabled(),
+          tauriUtils.getDrawingHintShown(),
+        ]);
         setDrawingPermanent(permanent);
-        const shown = await tauriUtils.getDrawingHintShown();
+        setDrawingEnabled(enabled);
         setHintShown(shown);
       } catch (error) {
-        console.error("Failed to load drawing permanent preference:", error);
+        console.error("Failed to load drawing preferences:", error);
       }
     };
-    loadPreference();
+    loadPreferences();
   }, []);
 
   const handlePermanentToggle = async (checked: boolean) => {
@@ -266,9 +271,10 @@ function DrawingEnableButton() {
     }
   };
 
-  const handleEnableDrawing = async () => {
+  const handleToggleDrawing = async () => {
+    const newEnabled = !drawingEnabled;
     try {
-      if (!hintShown) {
+      if (newEnabled && !hintShown) {
         await new Promise<void>((resolve) => {
           const toastDurationMs = 3_000;
           let dismissed = false;
@@ -306,15 +312,15 @@ function DrawingEnableButton() {
             dismissHintToast();
           }, toastDurationMs);
         });
-        await tauriUtils.enableDrawing(drawingPermanent);
         await tauriUtils.setDrawingHintShown(true);
         setHintShown(true);
-      } else {
-        await tauriUtils.enableDrawing(drawingPermanent);
       }
+
+      await tauriUtils.setDrawingEnabled(newEnabled, drawingPermanent);
+      setDrawingEnabled(newEnabled);
     } catch (error) {
-      console.error("Failed to enable drawing:", error);
-      toast.error("Failed to enable drawing", { duration: 2500 });
+      console.error("Failed to toggle drawing:", error);
+      toast.error("Failed to toggle drawing", { duration: 2500 });
     }
   };
 
@@ -326,13 +332,15 @@ function DrawingEnableButton() {
             <Button
               variant="outline"
               size="icon"
-              onClick={handleEnableDrawing}
+              onClick={handleToggleDrawing}
               className="rounded-none first:rounded-l-lg focus:z-10"
             >
-              <PiScribbleLoopBold className="size-4" />
+              {drawingEnabled ?
+                <PiCursorBold className="size-4" />
+              : <PiScribbleLoopBold className="size-4" />}
             </Button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">Enable drawing</TooltipContent>
+          <TooltipContent side="bottom">{drawingEnabled ? "Disable drawing" : "Enable drawing"}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
       <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>

--- a/tauri/src/components/ui/call-center.tsx
+++ b/tauri/src/components/ui/call-center.tsx
@@ -247,13 +247,11 @@ function DrawingEnableButton() {
   useEffect(() => {
     const loadPreferences = async () => {
       try {
-        const [permanent, enabled, shown] = await Promise.all([
+        const [permanent, shown] = await Promise.all([
           tauriUtils.getSharerDrawPersist(),
-          tauriUtils.getDrawingEnabled(),
           tauriUtils.getDrawingHintShown(),
         ]);
         setDrawingPermanent(permanent);
-        setDrawingEnabled(enabled);
         setHintShown(shown);
       } catch (error) {
         console.error("Failed to load drawing preferences:", error);

--- a/tauri/src/components/ui/call-center.tsx
+++ b/tauri/src/components/ui/call-center.tsx
@@ -262,6 +262,15 @@ function DrawingEnableButton() {
     loadPreferences();
   }, []);
 
+  useEffect(() => {
+    const unlisten = listen("core_drawing_disabled", () => {
+      setDrawingEnabled(false);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
   const handlePermanentToggle = async (checked: boolean) => {
     setDrawingPermanent(checked);
     try {

--- a/tauri/src/core_payloads.ts
+++ b/tauri/src/core_payloads.ts
@@ -181,7 +181,8 @@ export interface CommandMap {
   set_controller_draw_persist: { args: { persist: boolean }; return: void };
   get_drawing_hint_shown: { args: void; return: boolean };
   set_drawing_hint_shown: { args: { shown: boolean }; return: void };
-  enable_drawing: { args: { permanent: boolean }; return: void };
+  get_drawing_enabled: { args: void; return: boolean };
+  set_drawing_enabled: { args: { enabled: boolean; permanent: boolean }; return: void };
 
   // LiveKit
   set_livekit_url: { args: { url: string }; return: void };

--- a/tauri/src/core_payloads.ts
+++ b/tauri/src/core_payloads.ts
@@ -155,6 +155,7 @@ export interface CommandMap {
   set_deactivate_hiding: { args: { deactivate: boolean }; return: void };
   set_controller_cursor: { args: { enabled: boolean }; return: void };
   minimize_main_window: { args: void; return: void };
+  quit_app: { args: void; return: void };
 
   set_tray_notification: { args: { enabled: boolean }; return: void };
 

--- a/tauri/src/store/store.ts
+++ b/tauri/src/store/store.ts
@@ -171,7 +171,7 @@ let isProcessingUpdate = false;
 useStore.subscribe((state, prevState) => {
   // Don't emit if we're currently processing an update from another window
   if (isProcessingUpdate) return;
-  if (!isEqual(state, prevState)) {
+  if (windowName === "main" && !isEqual(state, prevState)) {
     emit("store-update", state);
   }
 
@@ -202,6 +202,9 @@ useStore.subscribe((state, prevState) => {
 
 // Set up listener for store updates from other windows
 listen("store-update", (event) => {
+  // Main is the source of truth; ignore cross-window writes into main.
+  if (windowName === "main") return;
+
   const newState = event.payload as State;
   // Only update if the state is different
   if (!isEqual(useStore.getState(), newState)) {
@@ -216,6 +219,9 @@ listen("store-update", (event) => {
 // Request current state from other windows when initializing
 let hasReceivedInitialState = false;
 listen("get-store-response", async (event) => {
+  // Main does not hydrate from peers.
+  if (windowName === "main") return;
+
   // The below replicates the race-condition issue
   // alongside swapping `get-store` emit/listen order
   // await new Promise((resolve) => setTimeout(resolve, 200));
@@ -232,6 +238,9 @@ emit("get-store");
 
 // Listen for state requests from new windows
 listen("get-store", () => {
+  // Only main responds with canonical state.
+  if (windowName !== "main") return;
+
   emit("get-store-response", {
     state: useStore.getState(),
     window: windowName,
@@ -242,6 +251,10 @@ listen("get-store", () => {
 // Also derive local audio/camera state so the UI stays in sync when toggled from core
 // (e.g. camera window mute button).
 listen<CoreParticipantState[]>("core_participants_snapshot", (event) => {
+  // Core snapshots should be processed by main window only.
+  // Non-main windows can race and rebroadcast stale callTokens via store sync.
+  if (windowName !== "main") return;
+
   const { callTokens, user } = useStore.getState();
   if (!callTokens) return;
 
@@ -266,13 +279,22 @@ listen<CoreParticipantState[]>("core_participants_snapshot", (event) => {
 });
 
 listen<number>("core_mic_audio_level", (event) => {
+  // Keep mic level updates single-writer to avoid cross-window state races
+  // (aux windows can rebroadcast stale callTokens role via store-sync).
+  if (windowName !== "main") return;
+
   const { callTokens } = useStore.getState();
   if (!callTokens) return;
+  if (callTokens.micLevel === event.payload) return;
+
   useStore.getState().updateCallTokens({ micLevel: event.payload });
 });
 
 // Listen for core role change events
 listen<CoreRoleEvent>("core_role_change", (event) => {
+  // Keep role derivation single-writer in main window.
+  if (windowName !== "main") return;
+
   const { callTokens } = useStore.getState();
   if (!callTokens) return;
 

--- a/tauri/src/windows/window-utils.ts
+++ b/tauri/src/windows/window-utils.ts
@@ -235,8 +235,12 @@ const setSharerDrawPersist = async (persist: boolean): Promise<void> => {
   return await invoke("set_sharer_draw_persist", { persist });
 };
 
-const enableDrawing = async (permanent: boolean): Promise<void> => {
-  await invoke("enable_drawing", { permanent });
+const getDrawingEnabled = async (): Promise<boolean> => {
+  return await invoke<boolean>("get_drawing_enabled");
+};
+
+const setDrawingEnabled = async (enabled: boolean, permanent: boolean): Promise<void> => {
+  return await invoke("set_drawing_enabled", { enabled, permanent });
 };
 
 const getDrawingHintShown = async (): Promise<boolean> => {
@@ -364,7 +368,8 @@ export const tauriUtils = {
   setLastUsedCamera,
   getSharerDrawPersist,
   setSharerDrawPersist,
-  enableDrawing,
+  getDrawingEnabled,
+  setDrawingEnabled,
   getDrawingHintShown,
   setDrawingHintShown,
   minimizeMainWindow,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Always-on-top drawing overlay window with participant cursors, click animations, persistent draw mode sync across viewers
  * New get/set drawing state APIs (toggle with optional persistent mode)

* **Updates**
  * Sharer draw-persist is synced live between participants
  * Subtler outline stroke rendering for drawn paths
  * Improved overlay opening/positioning and platform cursor handling (including macOS)

* **Bug Fixes**
  * Frontend promptly reflects core-driven drawing disable events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->