### PR TITLE
improvement: cmd+q kill the whole app

### DIFF
--- a/core/socket_lib/src/lib.rs
+++ b/core/socket_lib/src/lib.rs
@@ -236,6 +236,7 @@ pub enum Message {
     ActiveMicChanged(String),
     ActiveCameraChanged(String),
     DrawingDisabled,
+    ExitRequested,
     SetNoiseCancellation(bool),
     /// Microphone RMS level in [0.0, 1.0], emitted ~1 Hz from core capturer.
     MicrophoneAudioLevel(f32),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -516,6 +516,7 @@ impl<'a> Application<'a> {
                 last_mode: self.last_mode.clone(),
                 redraw_rx,
                 redraw_tx,
+                event_loop_proxy: self.event_loop_proxy.clone(),
             },
         ) {
             Ok(win) => self.screensharing_window = Some(win),
@@ -1825,6 +1826,12 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     self.close_drawing_window();
                 }
             }
+            UserEvent::ExitRequested => {
+                log::info!("user_event: ExitRequested");
+                if let Err(e) = self.socket.send(Message::ExitRequested) {
+                    log::error!("user_event: Error sending ExitRequested: {e:?}");
+                }
+            }
         }
     }
 
@@ -2225,6 +2232,7 @@ pub enum UserEvent {
     AudioCaptureError,
     SetNoiseCancellation(bool),
     CreateRoomResult(Result<Vec<socket_lib::CoreParticipantState>, String>),
+    ExitRequested,
 }
 
 pub struct RenderEventLoop {
@@ -2264,7 +2272,10 @@ impl RenderEventLoop {
         let mut event_loop = EventLoop::<UserEvent>::with_user_event();
 
         #[cfg(target_os = "macos")]
-        event_loop.with_activation_policy(winit::platform::macos::ActivationPolicy::Accessory);
+        {
+            event_loop.with_activation_policy(winit::platform::macos::ActivationPolicy::Accessory);
+            event_loop.with_default_menu(false);
+        }
 
         /* This is the beginning of the app, if this fails we can panic. */
         let event_loop = event_loop.build().expect("Failed to build event loop");

--- a/core/src/window/camera_window.rs
+++ b/core/src/window/camera_window.rs
@@ -469,6 +469,26 @@ impl CameraWindow {
             }
         }
 
+        // Intercept Cmd+Q to prevent app quit
+        #[cfg(target_os = "macos")]
+        if let WindowEvent::KeyboardInput {
+            event: ref key_event,
+            ..
+        } = event
+        {
+            if key_event.state.is_pressed() && self.modifiers.super_key() {
+                if let winit::keyboard::Key::Character(ref ch) = key_event.logical_key {
+                    if ch.as_ref() == "q" {
+                        log::info!("CameraWindow: caught Cmd+Q, requesting exit");
+                        let _ = self
+                            .event_loop_proxy
+                            .send_event(crate::UserEvent::ExitRequested);
+                        return;
+                    }
+                }
+            }
+        }
+
         // Handle winit-specific events
         match event {
             WindowEvent::ModifiersChanged(new_modifiers) => {

--- a/core/src/window/screensharing_window.rs
+++ b/core/src/window/screensharing_window.rs
@@ -29,7 +29,7 @@ use iced_winit::runtime::user_interface::Cache;
 use iced_winit::runtime::UserInterface;
 use iced_winit::{conversion, Clipboard};
 use winit::event::WindowEvent;
-use winit::event_loop::ActiveEventLoop;
+use winit::event_loop::{ActiveEventLoop, EventLoopProxy};
 use winit::keyboard::{Key, ModifiersState};
 #[cfg(not(target_os = "macos"))]
 use winit::window::CursorIcon;
@@ -441,6 +441,7 @@ pub struct ScreensharingWindow {
     redraw_in_progress: Arc<AtomicBool>,
     redraw_tx: std::sync::mpsc::Sender<RedrawCommand>,
     redraw_thread: Option<std::thread::JoinHandle<()>>,
+    event_loop_proxy: EventLoopProxy<crate::UserEvent>,
     aspect_ratio_enforcer: AspectRatioEnforcer,
     #[cfg(target_os = "macos")]
     ns_cursor_pointer: objc2::rc::Retained<objc2_app_kit::NSCursor>,
@@ -463,6 +464,7 @@ pub struct ScreensharingWindowConfig {
     pub last_mode: Option<socket_lib::StoredMode>,
     pub redraw_rx: std::sync::mpsc::Receiver<RedrawCommand>,
     pub redraw_tx: std::sync::mpsc::Sender<RedrawCommand>,
+    pub event_loop_proxy: EventLoopProxy<crate::UserEvent>,
 }
 
 impl ScreensharingWindow {
@@ -481,6 +483,7 @@ impl ScreensharingWindow {
             last_mode,
             redraw_rx,
             redraw_tx,
+            event_loop_proxy,
         } = config;
 
         let screen_area = probe_available_screen_area(event_loop);
@@ -691,6 +694,7 @@ impl ScreensharingWindow {
             redraw_in_progress,
             redraw_tx,
             redraw_thread: Some(redraw_thread),
+            event_loop_proxy,
             aspect_ratio_enforcer,
             #[cfg(target_os = "macos")]
             ns_cursor_pointer,
@@ -1192,6 +1196,20 @@ impl ScreensharingWindow {
             WindowEvent::KeyboardInput {
                 event: key_event, ..
             } => {
+                // Intercept Cmd+Q to gracefully exit instead of hard quit
+                #[cfg(target_os = "macos")]
+                if key_event.state.is_pressed() && self.modifiers.super_key() {
+                    if let Key::Character(ref ch) = key_event.logical_key {
+                        if ch.as_ref() == "q" {
+                            log::info!("ScreensharingWindow: caught Cmd+Q, requesting exit");
+                            let _ = self
+                                .event_loop_proxy
+                                .send_event(crate::UserEvent::ExitRequested);
+                            return input_event;
+                        }
+                    }
+                }
+
                 if self.mouse_in_participant_area
                     && self.state.active_tab == "control"
                     && self.state.remote_control_allowed

--- a/core/src/window/screensharing_window.rs
+++ b/core/src/window/screensharing_window.rs
@@ -441,6 +441,7 @@ pub struct ScreensharingWindow {
     redraw_in_progress: Arc<AtomicBool>,
     redraw_tx: std::sync::mpsc::Sender<RedrawCommand>,
     redraw_thread: Option<std::thread::JoinHandle<()>>,
+    #[cfg_attr(target_os = "windows", allow(dead_code))]
     event_loop_proxy: EventLoopProxy<crate::UserEvent>,
     aspect_ratio_enforcer: AspectRatioEnforcer,
     #[cfg(target_os = "macos")]

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1158,6 +1158,16 @@ fn forward_core_events(events_rx: std_mpsc::Receiver<Message>, app: tauri::AppHa
                     log::error!("forward_core_events: failed to emit core_drawing_disabled: {e:?}");
                 }
             }
+            Message::ExitRequested => {
+                log::info!("forward_core_events: exit requested from core");
+                let data = app.state::<Mutex<AppData>>();
+                let data = data.lock().unwrap();
+                if let Err(e) = data.sender.send(Message::CallEnd) {
+                    log::error!("forward_core_events: failed to send CallEnd: {e:?}");
+                }
+                drop(data);
+                app.exit(0);
+            }
             other => {
                 log::error!("forward_core_events: unhandled event: {other:?}");
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS: Added Cmd+Q shortcut to gracefully exit the app from any window, including screen sharing.
  * Exiting now triggers a clean shutdown flow that ends ongoing calls and closes the application process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->