### PR TITLE
impr: include user info in online websocket messages

### DIFF
--- a/backend/internal/handlers/websocketHandlers.go
+++ b/backend/internal/handlers/websocketHandlers.go
@@ -90,7 +90,7 @@ func CreateWSHandler(server *common.ServerState) echo.HandlerFunc {
 				}
 				if len(channels) > 0 {
 					c.Logger().Info("Notify teammate: ", teammate.ID, " that user: ", user.ID, " is online")
-					publishTeammateOnlineMessage(c, server, user.ID, teammate.ID)
+					publishTeammateOnlineMessage(c, server, user, teammate.ID)
 				}
 			}
 		}
@@ -158,7 +158,7 @@ func CreateWSHandler(server *common.ServerState) echo.HandlerFunc {
 				case parsedMessage.TeammateOnlineMessage != nil:
 					// Handle user online message
 					c.Logger().Info("Received user online message ", parsedMessage.TeammateOnlineMessage.Payload.TeammateID, " ", user.ID)
-					publishTeammateOnlineMessage(c, server, user.ID, parsedMessage.TeammateOnlineMessage.Payload.TeammateID)
+					publishTeammateOnlineMessage(c, server, user, parsedMessage.TeammateOnlineMessage.Payload.TeammateID)
 				default:
 					c.Logger().Warn("Unknown message type")
 				}
@@ -477,9 +477,9 @@ func endCall(ctx echo.Context, s *common.ServerState, userID string, message mes
 	s.Redis.Publish(context.Background(), common.GetUserChannel(message.Payload.ParticipantID), payloadJSON)
 }
 
-func publishTeammateOnlineMessage(ctx echo.Context, s *common.ServerState, userID, teammateID string) {
+func publishTeammateOnlineMessage(ctx echo.Context, s *common.ServerState, user *models.User, teammateID string) {
 	// Ping the teammate that user is online
-	msg := messages.NewTeammateOnlineMessage(userID)
+	msg := messages.NewTeammateOnlineMessageWithInfo(user.ID, user.FirstName, user.LastName, user.Email, user.AvatarURL)
 	msgJSON, err := json.Marshal(msg)
 	if err != nil {
 		ctx.Logger().Error(err)

--- a/backend/internal/handlers/websocketHandlers.go
+++ b/backend/internal/handlers/websocketHandlers.go
@@ -157,8 +157,12 @@ func CreateWSHandler(server *common.ServerState) echo.HandlerFunc {
 					}
 				case parsedMessage.TeammateOnlineMessage != nil:
 					// Handle user online message
-					c.Logger().Info("Received user online message ", parsedMessage.TeammateOnlineMessage.Payload.TeammateID, " ", user.ID)
-					publishTeammateOnlineMessage(c, server, user, parsedMessage.TeammateOnlineMessage.Payload.TeammateID)
+					teammateID := parsedMessage.TeammateOnlineMessage.Payload.TeammateID
+					c.Logger().Info("Received user online message ", teammateID, " ", user.ID)
+					if !canNotifyTeammate(c, server, user, teammateID) {
+						continue
+					}
+					publishTeammateOnlineMessage(c, server, user, teammateID)
 				default:
 					c.Logger().Warn("Unknown message type")
 				}
@@ -487,4 +491,27 @@ func publishTeammateOnlineMessage(ctx echo.Context, s *common.ServerState, user 
 	}
 
 	s.Redis.Publish(context.Background(), common.GetUserChannel(teammateID), msgJSON)
+}
+
+func canNotifyTeammate(ctx echo.Context, s *common.ServerState, user *models.User, teammateID string) bool {
+	if user.TeamID == nil || teammateID == "" || teammateID == user.ID {
+		ctx.Logger().Warn("Dropping unauthorized teammate_online message: ", user.ID, " -> ", teammateID)
+		return false
+	}
+
+	var count int64
+	err := s.DB.Model(&models.User{}).
+		Where("id = ? AND team_id = ?", teammateID, *user.TeamID).
+		Count(&count).Error
+	if err != nil {
+		ctx.Logger().Error("Failed to verify teammate_online recipient: ", err)
+		return false
+	}
+
+	if count == 0 {
+		ctx.Logger().Warn("Dropping teammate_online message for non-teammate: ", user.ID, " -> ", teammateID)
+		return false
+	}
+
+	return true
 }

--- a/backend/internal/messages/messages.go
+++ b/backend/internal/messages/messages.go
@@ -162,6 +162,10 @@ type CalleeOfflineMessage struct {
 // UserOnlinePayload represents the payload for user online messages
 type TeammateOnlinePayload struct {
 	TeammateID string `json:"teammate_id"`
+	FirstName  string `json:"first_name,omitempty"`
+	LastName   string `json:"last_name,omitempty"`
+	Email      string `json:"email,omitempty"`
+	AvatarURL  string `json:"avatar_url,omitempty"`
 }
 
 // UserOnlineMessage is the message to notify that a user has come online
@@ -343,6 +347,19 @@ func NewTeammateOnlineMessage(teammateID string) TeammateOnlineMessage {
 		Type: MessageTypeTeammateOnline,
 		Payload: TeammateOnlinePayload{
 			TeammateID: teammateID,
+		},
+	}
+}
+
+func NewTeammateOnlineMessageWithInfo(teammateID, firstName, lastName, email, avatarURL string) TeammateOnlineMessage {
+	return TeammateOnlineMessage{
+		Type: MessageTypeTeammateOnline,
+		Payload: TeammateOnlinePayload{
+			TeammateID: teammateID,
+			FirstName:  firstName,
+			LastName:   lastName,
+			Email:      email,
+			AvatarURL:  avatarURL,
 		},
 	}
 }

--- a/backend/internal/messages/messages_test.go
+++ b/backend/internal/messages/messages_test.go
@@ -1,0 +1,57 @@
+package messages
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTeammateOnlineMessageWithInfo(t *testing.T) {
+	msg := NewTeammateOnlineMessageWithInfo(
+		"user-123",
+		"Grace",
+		"Hopper",
+		"grace@example.com",
+		"https://example.com/avatar.png",
+	)
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal teammate online message: %v", err)
+	}
+
+	parsed, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("parse teammate online message: %v", err)
+	}
+
+	payload := parsed.TeammateOnlineMessage.Payload
+	if payload.TeammateID != "user-123" {
+		t.Fatalf("expected teammate_id user-123, got %q", payload.TeammateID)
+	}
+	if payload.FirstName != "Grace" || payload.LastName != "Hopper" {
+		t.Fatalf("expected teammate name in payload, got %q %q", payload.FirstName, payload.LastName)
+	}
+	if payload.Email != "grace@example.com" {
+		t.Fatalf("expected email in payload, got %q", payload.Email)
+	}
+	if payload.AvatarURL != "https://example.com/avatar.png" {
+		t.Fatalf("expected avatar_url in payload, got %q", payload.AvatarURL)
+	}
+}
+
+func TestTeammateOnlineMessageParsesLegacyPayload(t *testing.T) {
+	data := []byte(`{"type":"teammate_online","payload":{"teammate_id":"user-123"}}`)
+
+	parsed, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("parse legacy teammate online message: %v", err)
+	}
+
+	payload := parsed.TeammateOnlineMessage.Payload
+	if payload.TeammateID != "user-123" {
+		t.Fatalf("expected teammate_id user-123, got %q", payload.TeammateID)
+	}
+	if payload.FirstName != "" || payload.LastName != "" || payload.Email != "" || payload.AvatarURL != "" {
+		t.Fatalf("expected empty optional user info for legacy payload, got %+v", payload)
+	}
+}

--- a/tauri/src/payloads.ts
+++ b/tauri/src/payloads.ts
@@ -261,7 +261,13 @@ export const PCalleeOfflineMessage = z.object({
 
 export const PTeammateOnlineMessage = z.object({
   type: z.literal("teammate_online"),
-  payload: z.object({ teammate_id: z.string() }),
+  payload: z.object({
+    teammate_id: z.string(),
+    first_name: z.string().optional(),
+    last_name: z.string().optional(),
+    email: z.string().optional(),
+    avatar_url: z.string().optional(),
+  }),
 });
 
 // Export types for all messages


### PR DESCRIPTION
## Summary
- include optional user details in server-sent teammate_online websocket payloads
- keep teammate_id-only payloads compatible for existing client-to-server messages
- mirror the optional payload fields in the Tauri zod schema and add backend message tests

Closes #249

## Testing
- go test ./internal/messages
- go test ./internal/...
- yarn workspace hopp build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teammate online notifications now include optional profile details (first/last name, email, avatar) in WebSocket messages for richer presence information.

* **Tests**
  * Added tests covering messages with full profile data and ensuring legacy/compact message formats remain compatible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gethopp/hopp/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->