### PR TITLE
improvement: allow disabling telemetry

### DIFF
--- a/.github/workflows/publish-backend-image.yml
+++ b/.github/workflows/publish-backend-image.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Build web-app
         run: yarn workspace web-app build
+        env:
+          VITE_DISABLE_TELEMETRY: "true"
 
       - name: Inject web-app into backend
         run: cp web-app/static/react/assets/index.html backend/web/web-app.html

--- a/core/sentry_utils/src/lib.rs
+++ b/core/sentry_utils/src/lib.rs
@@ -3,8 +3,15 @@ use sentry::types::random_uuid;
 use sentry::{ClientInitGuard, Envelope, Level};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use sysinfo::System;
+
+static TELEMETRY_ENABLED: AtomicBool = AtomicBool::new(true);
+
+pub fn set_telemetry_enabled(enabled: bool) {
+    TELEMETRY_ENABLED.store(enabled, Ordering::Relaxed);
+}
 
 #[derive(Debug, Clone)]
 pub struct SentryMetadata {
@@ -84,6 +91,9 @@ fn get_system_tags() -> BTreeMap<String, String> {
 }
 
 pub fn upload_logs_event(failure_reason: String) {
+    if !TELEMETRY_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
     let client = match sentry::Hub::current().client() {
         Some(client) => client,
         None => {
@@ -173,6 +183,9 @@ fn pick_newest_by_filename(candidates: Vec<(PathBuf, Vec<u8>)>) -> Option<(PathB
 }
 
 pub fn upload_latest_crash() {
+    if !TELEMETRY_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
     #[cfg(target_os = "macos")]
     {
         let Some(dir) = diagnostic_reports_dir() else {
@@ -225,6 +238,9 @@ pub fn upload_latest_crash() {
 }
 
 pub fn simple_event(message: String) {
+    if !TELEMETRY_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
     let client = match sentry::Hub::current().client() {
         Some(client) => client,
         None => {

--- a/core/sentry_utils/src/lib.rs
+++ b/core/sentry_utils/src/lib.rs
@@ -15,15 +15,15 @@ pub fn set_telemetry_enabled(enabled: bool) {
 
 #[derive(Debug, Clone)]
 pub struct SentryMetadata {
-    pub user_email: String,
+    pub user_id: String,
     pub app_version: String,
 }
 
 static SENTRY_METADATA: OnceLock<SentryMetadata> = OnceLock::new();
 
-pub fn init_metadata(user_email: String, app_version: String) {
+pub fn init_metadata(user_id: String, app_version: String) {
     let metadata = SentryMetadata {
-        user_email,
+        user_id,
         app_version,
     };
 
@@ -79,7 +79,7 @@ fn get_system_tags() -> BTreeMap<String, String> {
     tags.insert("arch".to_string(), System::cpu_arch());
     match get_metadata() {
         Some(metadata) => {
-            tags.insert("user_email".to_string(), metadata.user_email.clone());
+            tags.insert("user_id".to_string(), metadata.user_id.clone());
             tags.insert("app_version".to_string(), metadata.app_version.clone());
         }
         None => {

--- a/core/sentry_utils/src/lib.rs
+++ b/core/sentry_utils/src/lib.rs
@@ -183,11 +183,12 @@ fn pick_newest_by_filename(candidates: Vec<(PathBuf, Vec<u8>)>) -> Option<(PathB
 }
 
 pub fn upload_latest_crash() {
-    if !TELEMETRY_ENABLED.load(Ordering::Relaxed) {
-        return;
-    }
     #[cfg(target_os = "macos")]
     {
+        if !TELEMETRY_ENABLED.load(Ordering::Relaxed) {
+            return;
+        }
+
         let Some(dir) = diagnostic_reports_dir() else {
             log::warn!("upload_latest_crash: no DiagnosticReports dir");
             return;

--- a/core/socket_lib/src/lib.rs
+++ b/core/socket_lib/src/lib.rs
@@ -113,7 +113,7 @@ pub struct CallStartMessage {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SentryMetadata {
-    pub user_email: String,
+    pub user_id: String,
     pub app_version: String,
 }
 

--- a/core/socket_lib/src/lib.rs
+++ b/core/socket_lib/src/lib.rs
@@ -240,6 +240,7 @@ pub enum Message {
     DrawingDisabled,
     ExitRequested,
     SetNoiseCancellation(bool),
+    SetTelemetryEnabled(bool),
     /// Microphone RMS level in [0.0, 1.0], emitted ~1 Hz from core capturer.
     MicrophoneAudioLevel(f32),
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1167,10 +1167,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
             }
             UserEvent::SentryMetadata(sentry_metadata) => {
                 log::debug!("user_event: Sentry metadata: {sentry_metadata:?}");
-                sentry_utils::init_metadata(
-                    sentry_metadata.user_email,
-                    sentry_metadata.app_version,
-                );
+                sentry_utils::init_metadata(sentry_metadata.user_id, sentry_metadata.app_version);
             }
             UserEvent::AddToClipboard(add_to_clipboard_data) => {
                 log::info!("user_event: Add to clipboard: {add_to_clipboard_data:?}");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1397,6 +1397,10 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                 self.noise_cancellation_enabled
                     .store(enabled, std::sync::atomic::Ordering::Relaxed);
             }
+            UserEvent::SetTelemetryEnabled(enabled) => {
+                log::info!("user_event: SetTelemetryEnabled({enabled})");
+                sentry_utils::set_telemetry_enabled(enabled);
+            }
             UserEvent::ToggleMic => {
                 log::info!("user_event: ToggleMic");
                 if let Some(room_service) = self.room_service.as_ref() {
@@ -2241,6 +2245,7 @@ pub enum UserEvent {
     DefaultInputDeviceChanged,
     AudioCaptureError,
     SetNoiseCancellation(bool),
+    SetTelemetryEnabled(bool),
     CreateRoomResult(Result<Vec<socket_lib::CoreParticipantState>, String>),
     ExitRequested,
 }
@@ -2393,6 +2398,9 @@ impl RenderEventLoop {
                     Message::BringWindowsToFront => UserEvent::BringWindowsToFront,
                     Message::SetNoiseCancellation(enabled) => {
                         UserEvent::SetNoiseCancellation(enabled)
+                    }
+                    Message::SetTelemetryEnabled(enabled) => {
+                        UserEvent::SetTelemetryEnabled(enabled)
                     }
                     // Ping is on purpose empty. We use it only for keeping the connection alive.
                     Message::Ping => {

--- a/docs/src/content/docs/open-source/self-hosting.md
+++ b/docs/src/content/docs/open-source/self-hosting.md
@@ -80,6 +80,12 @@ The web app served by your backend works without a rebuild — it derives the AP
 
 For the desktop app, you can set a custom backend URL at runtime via **Settings > Custom Backend URL** (see [Settings docs](/features/settings)).
 
+## Telemetry
+
+**Web app**: telemetry (PostHog analytics) is disabled by default in selfhosted builds. No data is sent to external services.
+
+**Desktop app**: when connecting to a selfhosted backend, disable telemetry from the desktop app **Settings**.
+
 ## Advanced
 
 ### Custom ports

--- a/tauri/src-tauri/src/app_state.rs
+++ b/tauri/src-tauri/src/app_state.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 pub use socket_lib::StoredMode;
 
+fn default_true() -> bool {
+    true
+}
+
 /// User-facing settings exposed in the Settings window.
 /// All fields are non-optional with sensible defaults.
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -14,6 +18,8 @@ pub struct UserSettings {
     pub shortcut_toggle_camera: Option<String>,
     pub shortcut_toggle_screenshare: Option<String>,
     pub shortcut_end_call: Option<String>,
+    #[serde(default = "default_true")]
+    pub telemetry_enabled: bool,
 }
 
 impl Default for UserSettings {
@@ -28,6 +34,7 @@ impl Default for UserSettings {
             shortcut_toggle_camera: None,
             shortcut_toggle_screenshare: None,
             shortcut_end_call: None,
+            telemetry_enabled: true,
         }
     }
 }

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -619,13 +619,13 @@ async fn create_content_picker_window(app: tauri::AppHandle) -> Result<(), Strin
 }
 
 #[tauri::command(async)]
-fn set_sentry_metadata(app: tauri::AppHandle, user_email: String, app_version: String) {
+fn set_sentry_metadata(app: tauri::AppHandle, user_id: String, app_version: String) {
     log::info!("set_sentry_metadata");
-    sentry_utils::init_metadata(user_email.clone(), app_version.clone());
+    sentry_utils::init_metadata(user_id.clone(), app_version.clone());
     let data = app.state::<Mutex<AppData>>();
     let data = data.lock().unwrap();
     if let Err(e) = data.sender.send(Message::SentryMetadata(SentryMetadata {
-        user_email,
+        user_id,
         app_version,
     })) {
         log::error!("set_sentry_metadata: failed to send message: {e:?}");

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -796,8 +796,8 @@ async fn create_settings_window(app: tauri::AppHandle) -> Result<(), String> {
             label: "settings",
             title: "Settings",
             url: "settings.html",
-            width: 680.0,
-            height: 740.0,
+            width: 740.0,
+            height: 800.0,
             resizable: false,
             always_on_top: false,
             content_protected: false,
@@ -908,6 +908,20 @@ fn set_call_feedback_popup(app: tauri::AppHandle, enabled: bool) {
     let mut data = data.lock().unwrap();
     data.app_state
         .update_user_setting(|s| s.call_feedback_popup = enabled);
+}
+
+#[tauri::command(async)]
+fn set_telemetry_enabled(app: tauri::AppHandle, enabled: bool) {
+    log::info!("set_telemetry_enabled: {enabled}");
+    let data = app.state::<Mutex<AppData>>();
+    let mut data = data.lock().unwrap();
+    data.app_state
+        .update_user_setting(|s| s.telemetry_enabled = enabled);
+    sentry_utils::set_telemetry_enabled(enabled);
+    if let Err(e) = data.sender.send(Message::SetTelemetryEnabled(enabled)) {
+        log::error!("set_telemetry_enabled: failed to send: {e:?}");
+    }
+    let _ = app.emit("telemetry_enabled_changed", enabled);
 }
 
 #[tauri::command(async)]
@@ -1457,6 +1471,13 @@ fn main() {
                     log::error!("Failed to send initial last_mode: {e:?}");
                 }
             }
+            {
+                let telemetry_enabled = app_state.user_settings().telemetry_enabled;
+                sentry_utils::set_telemetry_enabled(telemetry_enabled);
+                if let Err(e) = sender.send(Message::SetTelemetryEnabled(telemetry_enabled)) {
+                    log::error!("Failed to send initial telemetry_enabled: {e:?}");
+                }
+            }
             let data = Mutex::new(AppData::new(
                 sender,
                 event_socket,
@@ -1753,6 +1774,7 @@ fn main() {
             create_settings_window,
             get_user_settings,
             set_call_feedback_popup,
+            set_telemetry_enabled,
             set_show_dock_icon_in_call,
             set_start_camera_on_call,
             set_start_mic_on_call,

--- a/tauri/src/core_payloads.ts
+++ b/tauri/src/core_payloads.ts
@@ -76,7 +76,7 @@ export interface CallStartMessage {
 }
 
 export interface SentryMetadata {
-  user_email: string;
+  user_id: string;
   app_version: string;
 }
 
@@ -210,7 +210,7 @@ export interface CommandMap {
   create_settings_window: { args: void; return: void };
 
   // Sentry
-  set_sentry_metadata: { args: { userEmail: string; appVersion: string }; return: void };
+  set_sentry_metadata: { args: { userId: string; appVersion: string }; return: void };
 
   // Call
   call_started: { args: { audioToken: string; videoToken: string }; return: void };

--- a/tauri/src/core_payloads.ts
+++ b/tauri/src/core_payloads.ts
@@ -122,6 +122,7 @@ export interface UserSettings {
   shortcut_toggle_camera: string;
   shortcut_toggle_screenshare: string;
   shortcut_end_call: string;
+  telemetry_enabled: boolean;
 }
 
 export type CoreRoleChange = "Sharer" | "Controller" | "None";
@@ -223,6 +224,7 @@ export interface CommandMap {
   // User settings (Settings window)
   get_user_settings: { args: void; return: UserSettings };
   set_call_feedback_popup: { args: { enabled: boolean }; return: void };
+  set_telemetry_enabled: { args: { enabled: boolean }; return: void };
   set_show_dock_icon_in_call: { args: { enabled: boolean }; return: void };
   set_start_camera_on_call: { args: { enabled: boolean }; return: void };
   set_start_mic_on_call: { args: { enabled: boolean }; return: void };

--- a/tauri/src/services/sentry.tsx
+++ b/tauri/src/services/sentry.tsx
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { typedInvoke } from "@/core_payloads";
 
+// Helper function to set window context
 export const setWindowContext = async () => {
   try {
     const currentWindow = getCurrentWindow();
@@ -14,6 +15,7 @@ export const setWindowContext = async () => {
       title: await currentWindow.title(),
     });
   } catch (error) {
+    // Fallback for non-Tauri environments or errors
     Sentry.setTag("window", "unknown");
     Sentry.setContext("window", {
       name: "unknown",
@@ -23,6 +25,7 @@ export const setWindowContext = async () => {
   }
 };
 
+// Initialize Sentry and set up window context
 const sentryConfig: Sentry.BrowserOptions = {
   dsn: SENTRY_DSN,
   integrations: [
@@ -31,6 +34,8 @@ const sentryConfig: Sentry.BrowserOptions = {
     }),
     Sentry.browserTracingIntegration(),
   ],
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#general-integration-configuration
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/tauri/src/services/sentry.tsx
+++ b/tauri/src/services/sentry.tsx
@@ -1,8 +1,8 @@
 import { SENTRY_DSN } from "@/constants";
 import * as Sentry from "@sentry/react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { typedInvoke } from "@/core_payloads";
 
-// Helper function to set window context
 export const setWindowContext = async () => {
   try {
     const currentWindow = getCurrentWindow();
@@ -14,7 +14,6 @@ export const setWindowContext = async () => {
       title: await currentWindow.title(),
     });
   } catch (error) {
-    // Fallback for non-Tauri environments or errors
     Sentry.setTag("window", "unknown");
     Sentry.setContext("window", {
       name: "unknown",
@@ -24,8 +23,7 @@ export const setWindowContext = async () => {
   }
 };
 
-// Initialize Sentry and set up window context
-Sentry.init({
+const sentryConfig: Sentry.BrowserOptions = {
   dsn: SENTRY_DSN,
   integrations: [
     Sentry.captureConsoleIntegration({
@@ -33,12 +31,24 @@ Sentry.init({
     }),
     Sentry.browserTracingIntegration(),
   ],
-  // Learn more at
-  // https://docs.sentry.io/platforms/javascript/session-replay/configuration/#general-integration-configuration
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   tracesSampleRate: 1.0,
-});
+};
 
-// Set initial window context
+Sentry.init(sentryConfig);
 setWindowContext();
+
+export const disableSentry = () => {
+  Sentry.close();
+};
+
+export const enableSentry = () => {
+  Sentry.init(sentryConfig);
+};
+
+typedInvoke("get_user_settings").then((settings) => {
+  if (!settings.telemetry_enabled) {
+    disableSentry();
+  }
+});

--- a/tauri/src/services/sentry.tsx
+++ b/tauri/src/services/sentry.tsx
@@ -36,19 +36,25 @@ const sentryConfig: Sentry.BrowserOptions = {
   tracesSampleRate: 1.0,
 };
 
-Sentry.init(sentryConfig);
-setWindowContext();
+let sentryEnabled = false;
 
 export const disableSentry = () => {
-  Sentry.close();
+  if (sentryEnabled) {
+    Sentry.close();
+    sentryEnabled = false;
+  }
 };
 
-export const enableSentry = () => {
-  Sentry.init(sentryConfig);
+export const enableSentry = async () => {
+  if (!sentryEnabled) {
+    Sentry.init(sentryConfig);
+    await setWindowContext();
+    sentryEnabled = true;
+  }
 };
 
 typedInvoke("get_user_settings").then((settings) => {
-  if (!settings.telemetry_enabled) {
-    disableSentry();
+  if (settings.telemetry_enabled) {
+    enableSentry();
   }
 });

--- a/tauri/src/windows/main-window/app.tsx
+++ b/tauri/src/windows/main-window/app.tsx
@@ -59,7 +59,7 @@ function App() {
     select: (data) => {
       setUser(data);
       if (!sentryMetadataRef.current) {
-        tauriUtils.setSentryMetadata(data.email);
+        tauriUtils.setSentryMetadata(data.id);
         sentryMetadataRef.current = true;
       }
       return data;

--- a/tauri/src/windows/main-window/main.tsx
+++ b/tauri/src/windows/main-window/main.tsx
@@ -17,16 +17,29 @@ import { Toaster } from "react-hot-toast";
 import { PostHogProvider } from "posthog-js/react";
 import { PostHogConfig } from "posthog-js";
 import { BOTTOM_ARROW, POSTHOG_API_KEY, POSTHOG_HOST } from "@/constants";
+import { typedInvoke } from "@/core_payloads";
+import { listen } from "@tauri-apps/api/event";
+import posthog from "posthog-js";
 
 const options: Partial<PostHogConfig> = {
   api_host: POSTHOG_HOST,
   // Commenting out until we figure out WTF is going on
   // api_host: "https://webhook.site/4ce330a4-4bb3-497c-9cfe-997515e9093b",
   // autocapture: false,
-  loaded: function (ph) {
+  loaded: async function (ph) {
     if (import.meta.env.MODE == "development") {
-      ph.opt_out_capturing(); // opts a user out of event capture
+      ph.opt_out_capturing();
       ph.set_config({ disable_session_recording: true });
+    } else {
+      try {
+        const settings = await typedInvoke("get_user_settings");
+        if (!settings.telemetry_enabled) {
+          ph.opt_out_capturing();
+          ph.set_config({ disable_session_recording: true });
+        }
+      } catch {
+        // telemetry enabled by default
+      }
     }
   },
 };
@@ -48,6 +61,15 @@ if (BOTTOM_ARROW) {
 if (OS === "macos") {
   disableWebViewAppNap();
 }
+
+listen<boolean>("telemetry_enabled_changed", (event) => {
+  if (event.payload) {
+    posthog.opt_in_capturing();
+  } else {
+    posthog.opt_out_capturing();
+    posthog.set_config({ disable_session_recording: true });
+  }
+});
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/tauri/src/windows/main-window/main.tsx
+++ b/tauri/src/windows/main-window/main.tsx
@@ -28,7 +28,7 @@ const options: Partial<PostHogConfig> = {
   // autocapture: false,
   loaded: async function (ph) {
     if (import.meta.env.MODE == "development") {
-      ph.opt_out_capturing();
+      ph.opt_out_capturing(); // opts a user out of event capture
       ph.set_config({ disable_session_recording: true });
     } else {
       try {

--- a/tauri/src/windows/settings/main.tsx
+++ b/tauri/src/windows/settings/main.tsx
@@ -277,6 +277,21 @@ function SettingsWindow() {
           <div className="grid grid-cols-[minmax(100px,140px)_1fr] gap-8">
             <h3 className="text-base font-medium text-black dark:text-white">Miscellaneous</h3>
             <div className="flex flex-col gap-3">
+              <CheckboxRow
+                title="Send anonymous telemetry"
+                description="Help improve Hopp by sending anonymous usage data and error reports"
+                checked={settings.telemetry_enabled}
+                onCheckedChange={(v) => {
+                  typedInvoke("set_telemetry_enabled", { enabled: v }).then(() => {
+                    refetchSettings();
+                    if (v) {
+                      posthog.opt_in_capturing();
+                    } else {
+                      posthog.opt_out_capturing();
+                    }
+                  });
+                }}
+              />
               <div className="flex flex-col gap-1">
                 <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Custom Backend URL</span>
                 <span className="text-sm text-gray-500 dark:text-gray-400">

--- a/tauri/src/windows/window-utils.ts
+++ b/tauri/src/windows/window-utils.ts
@@ -263,9 +263,9 @@ const getLivekitUrl = async () => {
   return await invoke<string>("get_livekit_url");
 };
 
-const setSentryMetadata = async (userEmail: string) => {
+const setSentryMetadata = async (userId: string) => {
   const appVersion = await getVersion();
-  return await invoke("set_sentry_metadata", { userEmail, appVersion });
+  return await invoke("set_sentry_metadata", { userId, appVersion });
 };
 
 const callStarted = async (audioToken: string, videoToken: string) => {

--- a/web-app/src/App.tsx
+++ b/web-app/src/App.tsx
@@ -24,14 +24,8 @@ import { PostHogConfig } from "posthog-js";
 import { InvitationHandler } from "./pages/InvitationHandler";
 import { useCookies } from "react-cookie";
 
-const options: Partial<PostHogConfig> = {
+const posthogOptions: Partial<PostHogConfig> = {
   api_host: "https://eu.i.posthog.com",
-  loaded: function (ph) {
-    if (META.DEV_MODE) {
-      ph.opt_out_capturing(); // opts a user out of event capture
-      ph.set_config({ disable_session_recording: true });
-    }
-  },
 };
 
 export const queryClient = new QueryClient({
@@ -71,24 +65,32 @@ const Providers = ({ requireAuth, overrideRedirect = false }: { requireAuth: boo
   if (!requireAuth && authToken && !overrideRedirect) navigate("/dashboard");
   if (requireAuth && !authToken && !overrideRedirect) navigate("/login");
 
+  const telemetryEnabled = !META.DEV_MODE && !META.DISABLE_TELEMETRY;
+
+  const content = (
+    <QueryClientProvider client={queryClient}>
+      <QueryProvider>
+        <ReactQueryDevtools initialIsOpen={false} />
+        {!authToken && <Outlet />}
+        {authToken && (
+          <SidebarProvider>
+            <HoppSidebar />
+            <main className="p-8 w-full">
+              <Outlet />
+            </main>
+          </SidebarProvider>
+        )}
+      </QueryProvider>
+    </QueryClientProvider>
+  );
+
   return (
     <div className="w-screen h-screen">
-      <PostHogProvider apiKey="phc_qOumHIIkywfbcmxjoI84orWP5Wo2oZVamh83bOUeF5x" options={options}>
-        <QueryClientProvider client={queryClient}>
-          <QueryProvider>
-            <ReactQueryDevtools initialIsOpen={false} />
-            {!authToken && <Outlet />}
-            {authToken && (
-              <SidebarProvider>
-                <HoppSidebar />
-                <main className="p-8 w-full">
-                  <Outlet />
-                </main>
-              </SidebarProvider>
-            )}
-          </QueryProvider>
-        </QueryClientProvider>
-      </PostHogProvider>
+      {telemetryEnabled ?
+        <PostHogProvider apiKey="phc_qOumHIIkywfbcmxjoI84orWP5Wo2oZVamh83bOUeF5x" options={posthogOptions}>
+          {content}
+        </PostHogProvider>
+      : content}
     </div>
   );
 };

--- a/web-app/src/constants.ts
+++ b/web-app/src/constants.ts
@@ -20,6 +20,9 @@ export const META = {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore - MODE is set by the Vite environment
   DEV_MODE: import.meta.env.MODE === "development",
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - VITE_DISABLE_TELEMETRY is defined by us with Vite naming convention
+  DISABLE_TELEMETRY: import.meta.env.VITE_DISABLE_TELEMETRY === "true",
 };
 
 export const BACKEND_URLS = {

--- a/web-app/src/pages/Dashboard.tsx
+++ b/web-app/src/pages/Dashboard.tsx
@@ -123,7 +123,7 @@ export function Dashboard() {
     }
 
     if (downloadUrl) {
-      posthog.capture("app_download_attempted", {
+      posthog?.capture("app_download_attempted", {
         platform: platformName,
         download_type: "direct_download",
       });
@@ -136,7 +136,7 @@ export function Dashboard() {
       document.body.removeChild(link);
       toast.success("Download started!");
     } else {
-      posthog.capture("app_download_failed", {
+      posthog?.capture("app_download_failed", {
         platform: platformName,
         error_reason: "download_url_not_found",
       });
@@ -306,7 +306,7 @@ export function Dashboard() {
       return;
     }
 
-    posthog.capture("invite_teammates_clicked", {
+    posthog?.capture("invite_teammates_clicked", {
       method: "email_invites",
       invite_count: emailOptions.length,
     });
@@ -418,7 +418,7 @@ export function Dashboard() {
                   <Input id="invite-url" value={inviteUrl} disabled className="max-w-md" />
                   <CopyButton
                     onCopy={() => {
-                      posthog.capture("invite_link_copied", {
+                      posthog?.capture("invite_link_copied", {
                         method: "copy_button",
                       });
                       navigator.clipboard.writeText(inviteUrl);


### PR DESCRIPTION
* Telemetry is disabled by default on the self hosted backend. 
* Telemetry can be disabled on the desktop app from the settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Send anonymous telemetry” checkbox in Settings to enable/disable telemetry across the app; changes apply immediately and are honored at startup.
  * Telemetry being disabled prevents analytics/session recording from running.

* **Bug Fixes**
  * Analytics calls made resilient so missing telemetry won’t cause errors.

* **Documentation**
  * Self-hosting guide notes telemetry is disabled by default for self-hosted web builds and how to manage it from the desktop app.

* **UI**
  * Settings window size adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->