### PR TITLE
feat: enable auto-updates for macOS

### DIFF
--- a/tauri/src-tauri/src/app_state.rs
+++ b/tauri/src-tauri/src/app_state.rs
@@ -20,6 +20,8 @@ pub struct UserSettings {
     pub shortcut_end_call: Option<String>,
     #[serde(default = "default_true")]
     pub telemetry_enabled: bool,
+    #[serde(default = "default_true")]
+    pub auto_update_enabled: bool,
 }
 
 impl Default for UserSettings {
@@ -35,6 +37,7 @@ impl Default for UserSettings {
             shortcut_toggle_screenshare: None,
             shortcut_end_call: None,
             telemetry_enabled: true,
+            auto_update_enabled: true,
         }
     }
 }

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -934,6 +934,15 @@ fn set_show_dock_icon_in_call(app: tauri::AppHandle, enabled: bool) {
 }
 
 #[tauri::command(async)]
+fn set_auto_update_enabled(app: tauri::AppHandle, enabled: bool) {
+    log::info!("set_auto_update_enabled: {enabled}");
+    let data = app.state::<Mutex<AppData>>();
+    let mut data = data.lock().unwrap();
+    data.app_state
+        .update_user_setting(|s| s.auto_update_enabled = enabled);
+}
+
+#[tauri::command(async)]
 fn set_start_camera_on_call(app: tauri::AppHandle, enabled: bool) {
     log::info!("set_start_camera_on_call: {enabled}");
     let data = app.state::<Mutex<AppData>>();
@@ -1776,6 +1785,7 @@ fn main() {
             set_call_feedback_popup,
             set_telemetry_enabled,
             set_show_dock_icon_in_call,
+            set_auto_update_enabled,
             set_start_camera_on_call,
             set_start_mic_on_call,
             set_shortcut_toggle_mic,

--- a/tauri/src/components/sidebar/Sidebar.tsx
+++ b/tauri/src/components/sidebar/Sidebar.tsx
@@ -22,7 +22,7 @@ import {
 import { appVersion, tauriUtils } from "@/windows/window-utils.ts";
 import { Constants, OS } from "@/constants";
 import { useQueryClient } from "@tanstack/react-query";
-import { downloadAndRelaunch } from "@/update";
+import { downloadAndRelaunch, hasPendingUpdate, installAndRelaunch } from "@/update";
 import { LuCircleFadingArrowUp } from "react-icons/lu";
 
 const SidebarButton = ({
@@ -119,6 +119,10 @@ const DownloadNewVersionButton = () => {
           className="flex items-center justify-center rounded-lg bg-white bg-linear-to-b from-gray-100 p-1.5 border border-slate-300 mx-1 size-8 w-full hover:scale-[1.025] hover:shadow-xs transition-all duration-300"
           onClick={() => {
             setUpdateInProgress(true);
+            if (OS === "macos" && hasPendingUpdate()) {
+              void installAndRelaunch();
+              return;
+            }
             void downloadAndRelaunch();
           }}
           disabled={updateInProgress}

--- a/tauri/src/core_payloads.ts
+++ b/tauri/src/core_payloads.ts
@@ -123,6 +123,7 @@ export interface UserSettings {
   shortcut_toggle_screenshare: string;
   shortcut_end_call: string;
   telemetry_enabled: boolean;
+  auto_update_enabled: boolean;
 }
 
 export type CoreRoleChange = "Sharer" | "Controller" | "None";
@@ -226,6 +227,7 @@ export interface CommandMap {
   set_call_feedback_popup: { args: { enabled: boolean }; return: void };
   set_telemetry_enabled: { args: { enabled: boolean }; return: void };
   set_show_dock_icon_in_call: { args: { enabled: boolean }; return: void };
+  set_auto_update_enabled: { args: { enabled: boolean }; return: void };
   set_start_camera_on_call: { args: { enabled: boolean }; return: void };
   set_start_mic_on_call: { args: { enabled: boolean }; return: void };
   set_shortcut_toggle_mic: { args: { accel: string }; return: void };

--- a/tauri/src/lib/auto-update.ts
+++ b/tauri/src/lib/auto-update.ts
@@ -1,0 +1,35 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { OS } from "@/constants";
+import { typedInvoke } from "@/core_payloads";
+import useStore from "@/store/store";
+import { checkForUpdates, downloadUpdateInBackground, installAndRelaunch } from "@/update";
+
+/** Safe to interrupt: no call activity and the window isn't in front of the user. */
+async function isIdle(): Promise<boolean> {
+  const { callTokens, incomingCallCallerId, calling, updateInProgress } = useStore.getState();
+  if (callTokens || incomingCallCallerId || calling || updateInProgress) return false;
+  return !(await getCurrentWindow().isFocused());
+}
+
+/** Refresh the update badge, and on macOS auto-install when the user is idle. */
+export async function pollUpdates(setNeedsUpdate: (needsUpdate: boolean) => void) {
+  try {
+    const update = await checkForUpdates();
+    setNeedsUpdate(update !== null);
+
+    if (OS !== "macos" || !update) return;
+
+    const { auto_update_enabled } = await typedInvoke("get_user_settings");
+    if (!auto_update_enabled) return;
+
+    await downloadUpdateInBackground();
+
+    if (await isIdle()) {
+      useStore.getState().setUpdateInProgress(true);
+      await installAndRelaunch();
+    }
+  } catch (err) {
+    console.error("Auto-update poll failed:", err);
+    useStore.getState().setUpdateInProgress(false);
+  }
+}

--- a/tauri/src/update.ts
+++ b/tauri/src/update.ts
@@ -1,39 +1,63 @@
-import { check } from '@tauri-apps/plugin-updater';
-import { relaunch } from '@tauri-apps/plugin-process';
+import { check, Update } from "@tauri-apps/plugin-updater";
+import { relaunch } from "@tauri-apps/plugin-process";
+
+let pendingUpdate: Update | null = null;
 
 export async function checkForUpdates() {
-    const update = await check();
-    if (update) {
-        console.debug(
-            `found update ${update.version} from ${update.date} with notes ${update.body}`
-        )
-    }
-    return update;
+  const update = await check();
+  if (update) {
+    console.debug(`found update ${update.version} from ${update.date} with notes ${update.body}`);
+  }
+  return update;
+}
+
+export function hasPendingUpdate() {
+  return pendingUpdate !== null;
+}
+
+export async function downloadUpdateInBackground() {
+  if (pendingUpdate) return pendingUpdate;
+
+  const update = await check();
+  if (!update) return null;
+
+  await update.download();
+  pendingUpdate = update;
+  console.debug(`downloaded update ${update.version} in background`);
+  return update;
+}
+
+export async function installAndRelaunch() {
+  if (!pendingUpdate) return false;
+
+  await pendingUpdate.install();
+  console.debug("update installed");
+  await relaunch();
+  return true;
 }
 
 export async function downloadAndRelaunch() {
-    const update = await check();
-    if (update) {
-        let downloaded = 0;
-        let contentLength: number | undefined = 0;
-        // alternatively we could also call update.download() and update.install() separately
-        await update.downloadAndInstall((event) => {
-            switch (event.event) {
-                case 'Started':
-                    contentLength = event.data.contentLength;
-                    console.debug(`started downloading ${event.data.contentLength} bytes`);
-                    break;
-                case 'Progress':
-                    downloaded += event.data.chunkLength;
-                    console.debug(`downloaded ${downloaded} from ${contentLength}`);
-                    break;
-                case 'Finished':
-                    console.debug('download finished');
-                    break;
-            }
-        });
+  const update = await check();
+  if (update) {
+    let downloaded = 0;
+    let contentLength: number | undefined = 0;
+    await update.downloadAndInstall((event) => {
+      switch (event.event) {
+        case "Started":
+          contentLength = event.data.contentLength;
+          console.debug(`started downloading ${event.data.contentLength} bytes`);
+          break;
+        case "Progress":
+          downloaded += event.data.chunkLength;
+          console.debug(`downloaded ${downloaded} from ${contentLength}`);
+          break;
+        case "Finished":
+          console.debug("download finished");
+          break;
+      }
+    });
 
-        console.debug('update installed');
-        await relaunch();
-    }
+    console.debug("update installed");
+    await relaunch();
+  }
 }

--- a/tauri/src/windows/main-window/app.tsx
+++ b/tauri/src/windows/main-window/app.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef } from "react";
 import { differenceInSeconds, fromUnixTime } from "date-fns";
 import { Button } from "@/components/ui/button";
 import { onOpenUrl } from "@tauri-apps/plugin-deep-link";
-import { checkForUpdates } from "@/update.ts";
 import useStore from "../../store/store";
 import { tauriUtils } from "@/windows/window-utils.ts";
 import { Sidebar } from "@/components/sidebar/Sidebar";
@@ -26,6 +25,7 @@ import { sounds } from "@/constants/sounds";
 import { useDisableNativeContextMenu } from "@/lib/hooks";
 import { processDeepLinkUrl } from "@/lib/deepLinkUtils";
 import { Rooms } from "./tabs/Rooms";
+import { pollUpdates } from "@/lib/auto-update";
 
 function App() {
   const {
@@ -162,25 +162,15 @@ function App() {
     };
   }, []);
 
-  // Check for updates
+  // Check for updates (and auto-install when idle on macOS)
   useEffect(() => {
     if (!isTauri()) return;
 
-    const checkUpdates = async () => {
-      try {
-        const needUpdate = await checkForUpdates();
-        setNeedsUpdate(needUpdate !== null);
-      } catch (err) {
-        console.error("Failed to check for updates:", err);
-      }
-    };
-
-    checkUpdates();
-
-    const interval = setInterval(checkUpdates, 60 * 60 * 1000);
+    pollUpdates(setNeedsUpdate);
+    const interval = setInterval(() => pollUpdates(setNeedsUpdate), 15 * 60 * 1000);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [setNeedsUpdate]);
 
   const handleReject = (isInCall?: boolean) => {
     const { incomingCallCallerId } = useStore.getState();


### PR DESCRIPTION
Add auto update functionality for macOS. 

Did not add for Windows, as they need to always click and accept the installation.

Also users can opt-out from this, and click explicitly to update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now enable or disable automatic updates via a new setting.
  * On macOS, updates can download in the background while the app is idle.

* **Improvements**
  * Automatic update checking now occurs on a periodic schedule.
  * Update button intelligently handles platform-specific update flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->