### PR TITLE
design: redesign call center and more

### DIFF
--- a/docs/src/content/docs/features/keyboard-navigation.mdx
+++ b/docs/src/content/docs/features/keyboard-navigation.mdx
@@ -8,3 +8,13 @@ Hopp's goal is to remove as much friction as possible from your screen sharing w
 ## Start screen sharing without leaving your keyboard
 
 <video src="/keyboard-share.mp4" controls class="rounded-md max-w-full mx-auto mt-6" autoplay loop muted></video>
+
+## In-app shortcuts
+
+These shortcuts only work when the Hopp window is focused.
+
+| Action          | macOS | Windows  |
+| --------------- | ----- | -------- |
+| Go to call view | `⌘O`  | `Ctrl+O` |
+
+While in an ongoing call, press **⌘O** (macOS) or **Ctrl+O** (Windows) to jump to the call view from anywhere inside the app.

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -724,7 +724,11 @@ fn call_started(
 
 /// When enabled=true, shows the notification variant of the icon.
 /// When enabled=false, shows the default variant.
-#[tauri::command(async)]
+///
+/// NOTE: must NOT be `async`. The macOS implementation manipulates AppKit/CALayer,
+/// which has to run on the main thread; an async command would run off-thread and
+/// the notification dot would silently never update.
+#[tauri::command]
 fn set_tray_notification(app: tauri::AppHandle, enabled: bool) {
     log::info!("set_tray_notification: enabled={}", enabled);
     let data = app.state::<std::sync::Mutex<hopp::AppData>>();

--- a/tauri/src/App.css
+++ b/tauri/src/App.css
@@ -625,3 +625,21 @@ html.dark .trayNotification-body {
 html.dark .trayNotification-body #root {
   background-color: var(--bg-gray-dark);
 }
+
+kbd {
+  /* Inspired by: https://dylanatsmith.com/wrote/styling-the-kbd-element */
+  background-color: theme("colors.gray.100");
+  color: theme("colors.gray.900");
+  border-radius: 0.25rem; /* rounded */
+  border: 1px solid theme("colors.gray.300");
+  box-shadow: 0 0.5px 0 0.5px theme("colors.gray.300");
+  cursor: default;
+  font-family: theme("fontFamily.sans");
+  min-width: 0.75rem;
+  display: block;
+  text-align: center;
+  padding: 2px 5px;
+  margin: 0 4px;
+  position: relative;
+  top: -1px;
+}

--- a/tauri/src/components/sidebar/Sidebar.tsx
+++ b/tauri/src/components/sidebar/Sidebar.tsx
@@ -24,6 +24,8 @@ import { Constants, OS } from "@/constants";
 import { useQueryClient } from "@tanstack/react-query";
 import { downloadAndRelaunch } from "@/update";
 import { LuCircleFadingArrowUp } from "react-icons/lu";
+import { FiPhoneCall } from "react-icons/fi";
+import hotkeys from "hotkeys-js";
 
 const SidebarButton = ({
   active,
@@ -227,6 +229,45 @@ const TrialCountdownAvatarFill = ({ user }: { user: components["schemas"]["Priva
   );
 };
 
+const CallPageButton = () => {
+  const { tab, setTab, callTokens } = useStore();
+
+  // Local shortcut to jump to the call page while in a call. hotkeys-js binds to
+  // the webview document, so it only fires when the main window is focused.
+  useEffect(() => {
+    if (!callTokens) return;
+    hotkeys("cmd+o, ctrl+o", (event) => {
+      event.preventDefault();
+      setTab("call");
+    });
+    return () => hotkeys.unbind("cmd+o, ctrl+o");
+  }, [callTokens, setTab]);
+
+  if (!callTokens) return null;
+
+  const active = tab === "call";
+  const shortcutLabel = OS === "macos" ? "⌘O" : "Ctrl+O";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => setTab("call")}
+          className={clsx(
+            "p-1.5 rounded-md flex items-center justify-center size-8 border border-green-500",
+            !active && "hover:bg-green-50",
+            active && "bg-white shadow-xs",
+          )}
+        >
+          <FiPhoneCall className="size-4 text-green-500" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right" className="flex flex-row items-center">Ongoing call <kbd className="max-w-min text-xs leading-3">{shortcutLabel}</kbd></TooltipContent>
+    </Tooltip>
+  );
+};
+
 export const Sidebar = () => {
   const { tab, setTab, user, reset } = useStore();
   const queryClient = useQueryClient();
@@ -254,6 +295,9 @@ export const Sidebar = () => {
           )}
         </div>
         <Separator className="w-[70%] mx-auto" />
+        <div className="flex justify-center w-full pt-2">
+          <CallPageButton />
+        </div>
         {/* Bottom user section */}
         <div className="flex flex-col gap-1 mt-auto">
           <div className="flex justify-center w-full">

--- a/tauri/src/components/ui/call-center.tsx
+++ b/tauri/src/components/ui/call-center.tsx
@@ -21,8 +21,10 @@ import { CustomIcons } from "@/components/ui/icons";
 import clsx from "clsx";
 import { ChevronDownIcon } from "@radix-ui/react-icons";
 import { MoreHorizontal, X } from "lucide-react";
-import { HiOutlinePhoneXMark } from "react-icons/hi2";
+import { HiOutlinePhoneXMark, HiMiniLink } from "react-icons/hi2";
 import toast from "react-hot-toast";
+import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+import { Constants } from "@/constants";
 import { useEndCall } from "@/lib/hooks";
 import { typedInvoke } from "@/core_payloads";
 import { useQuery } from "@tanstack/react-query";
@@ -51,6 +53,13 @@ export function CallCenter() {
   const handleEndCall = useEndCall();
   const handleEndCallRef = useRef(handleEndCall);
   handleEndCallRef.current = handleEndCall;
+
+  const handleCopyRoomLink = async () => {
+    if (!callTokens?.room) return;
+    const roomLink = `${Constants.webAppUrl}/room/${callTokens.room.id}`;
+    await writeText(roomLink);
+    toast.success("Room link copied to clipboard");
+  };
 
   const fetchAccessibilityPermission = async () => {
     const permission = await tauriUtils.getControlPermission();
@@ -115,17 +124,46 @@ export function CallCenter() {
         )}
 
         {/* Call Timer */}
-        {!callTokens.isInitialisingCall && (
-          <div className="w-full text-center mb-4">
-            <span className="text-xs font-medium">Pairing</span>{" "}
-            <span className="text-xs muted font-medium">
-              started{" "}
-              {formatDistanceToNow(callTokens.timeStarted, {
-                addSuffix: true,
-              })}
-            </span>
-          </div>
-        )}
+        {!callTokens.isInitialisingCall &&
+          (callTokens.room ?
+            <div className="w-full flex flex-col items-center gap-0.5 mb-4">
+              <div className="flex items-center justify-center gap-1.5">
+                <span className="text-xs font-medium">{callTokens.room.name}</span>
+                <TooltipProvider delayDuration={100}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={handleCopyRoomLink}
+                        className="flex items-center justify-center size-5 rounded-sm text-slate-500 hover:bg-slate-200 hover:text-slate-700"
+                        aria-label="Copy room link"
+                      >
+                        <HiMiniLink className="size-3" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" className="flex flex-col items-center gap-0">
+                      <span>Copy room link for web</span>
+                      <span className="text-xs text-slate-400">Share with teammates</span>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </div>
+              <span className="text-xs muted font-medium">
+                started{" "}
+                {formatDistanceToNow(callTokens.timeStarted, {
+                  addSuffix: true,
+                })}
+              </span>
+            </div>
+            : <div className="w-full text-center mb-4">
+              <span className="text-xs font-medium">Pairing</span>{" "}
+              <span className="text-xs muted font-medium">
+                started{" "}
+                {formatDistanceToNow(callTokens.timeStarted, {
+                  addSuffix: true,
+                })}
+              </span>
+            </div>)}
       </div>
       <div className="gap-2 px-3 flex flex-col items-center w-full mb-2">
         <div className="flex flex-row gap-1 w-full">
@@ -161,9 +199,9 @@ export function CallCenter() {
                       }}
                       state={
                         controllerCursorState ? "active"
-                        : !accessibilityPermission ?
-                          "deactivated"
-                        : "neutral"
+                          : !accessibilityPermission ?
+                            "deactivated"
+                            : "neutral"
                       }
                       size="unsized"
                       className="size-9"
@@ -204,8 +242,8 @@ export function CallCenter() {
                   </Button>
                 </TooltipTrigger>
                 {userSettings?.shortcut_end_call && (
-                  <TooltipContent side="bottom" variant="light">
-                    <span className="font-mono text-xs">{userSettings.shortcut_end_call}</span>
+                  <TooltipContent sideOffset={0} side="bottom" variant="transparent">
+                    <kbd className="text-xs">{userSettings.shortcut_end_call}</kbd>
                   </TooltipContent>
                 )}
               </Tooltip>
@@ -254,7 +292,7 @@ function CallParticipants() {
           isLocal: true,
           isMicrophoneEnabled: callTokens?.hasAudioEnabled ?? true,
         }
-      : null;
+        : null;
 
     const remoteEntries = coreParticipants
       .filter((p) => p.connected)
@@ -294,7 +332,7 @@ function CallParticipants() {
                       alt={`${participant.user.first_name} ${participant.user.last_name}`}
                       className="size-full object-cover"
                     />
-                  : <span className="text-[10px] font-medium text-emerald-700">
+                    : <span className="text-[10px] font-medium text-emerald-700">
                       {participant.user.first_name[0]}
                       {participant.user.last_name[0]}
                     </span>
@@ -313,7 +351,7 @@ function CallParticipants() {
                   )}
                 </div>
               </>
-            : <>
+              : <>
                 <div className="size-8 rounded-md bg-slate-200 flex items-center justify-center shrink-0">
                   <span className="text-xs font-medium text-slate-600">?</span>
                 </div>
@@ -438,7 +476,7 @@ function DrawingEnableButton() {
             >
               {drawingEnabled ?
                 <PiCursorBold className="size-4" />
-              : <PiScribbleLoopBold className="size-4" />}
+                : <PiScribbleLoopBold className="size-4" />}
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">{drawingEnabled ? "Disable drawing" : "Enable drawing"}</TooltipContent>
@@ -581,7 +619,7 @@ function MicrophoneIcon({ shortcut }: { shortcut?: string }) {
                     level={callTokens?.micLevel ?? 0}
                     className={`size-4 ${Colors.mic.icon} relative z-10`}
                   />
-                : <LuMicOff className={`size-4 ${Colors.deactivatedIcon} relative z-10`} />}
+                  : <LuMicOff className={`size-4 ${Colors.deactivatedIcon} relative z-10`} />}
               </div>
             }
             state={hasAudioEnabled ? "active" : "neutral"}
@@ -622,8 +660,8 @@ function MicrophoneIcon({ shortcut }: { shortcut?: string }) {
           </ToggleIconButton>
         </TooltipTrigger>
         {shortcut && (
-          <TooltipContent side="bottom" variant="light">
-            <span className="font-mono text-xs">{shortcut}</span>
+          <TooltipContent sideOffset={0} side="bottom" variant="transparent">
+            <kbd className="text-xs">{shortcut}</kbd>
           </TooltipContent>
         )}
       </Tooltip>
@@ -663,7 +701,7 @@ function ScreenShareIcon({ callTokens, shortcut }: { callTokens: CallState | nul
             icon={
               callTokens?.role === ParticipantRole.SHARER ?
                 <LuScreenShareOff className={`size-4 ${Colors.screen.icon}`} />
-              : <LuScreenShare className={`size-4 ${Colors.deactivatedIcon}`} />
+                : <LuScreenShare className={`size-4 ${Colors.deactivatedIcon}`} />
             }
             state={callTokens?.role === ParticipantRole.SHARER ? "active" : "neutral"}
             size="unsized"
@@ -691,8 +729,8 @@ function ScreenShareIcon({ callTokens, shortcut }: { callTokens: CallState | nul
           </ToggleIconButton>
         </TooltipTrigger>
         {shortcut && (
-          <TooltipContent side="bottom" variant="light">
-            <span className="font-mono text-xs">{shortcut}</span>
+          <TooltipContent sideOffset={0} side="bottom" variant="transparent">
+            <kbd className="text-xs">{shortcut}</kbd>
           </TooltipContent>
         )}
       </Tooltip>
@@ -815,7 +853,7 @@ function CameraIcon({ shortcut }: { shortcut?: string }) {
             icon={
               cameraEnabled ?
                 <LuVideo className={`size-4 ${Colors.camera.icon}`} />
-              : <LuVideoOff className={`size-4 ${Colors.deactivatedIcon}`} />
+                : <LuVideoOff className={`size-4 ${Colors.deactivatedIcon}`} />
             }
             state={cameraEnabled ? "active" : "neutral"}
             size="unsized"
@@ -851,8 +889,8 @@ function CameraIcon({ shortcut }: { shortcut?: string }) {
           </ToggleIconButton>
         </TooltipTrigger>
         {shortcut && (
-          <TooltipContent side="bottom" variant="light">
-            <span className="font-mono text-xs">{shortcut}</span>
+          <TooltipContent sideOffset={0} side="bottom" variant="transparent">
+            <kbd className="text-xs">{shortcut}</kbd>
           </TooltipContent>
         )}
       </Tooltip>

--- a/tauri/src/components/ui/tooltip.tsx
+++ b/tauri/src/components/ui/tooltip.tsx
@@ -9,11 +9,12 @@ const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
-type TooltipVariant = "default" | "light";
+type TooltipVariant = "default" | "light" | "transparent";
 
 const tooltipVariantClasses: Record<TooltipVariant, string> = {
   default: "bg-slate-900 text-slate-50 dark:bg-slate-50 dark:text-slate-900",
   light: "bg-white text-slate-600 ring-1 ring-slate-200 shadow-sm",
+  transparent: "bg-transparent text-slate-600",
 };
 
 const TooltipContent = React.forwardRef<

--- a/tauri/src/store/store.ts
+++ b/tauri/src/store/store.ts
@@ -10,7 +10,7 @@ import type { CoreParticipantState, CoreRoleEvent } from "@/core_payloads";
 
 const windowName = getCurrentWindow().label;
 
-export const SidebarTabs = ["user-list", "invite", "debug", "login", "report-issue", "rooms"] as const;
+export const SidebarTabs = ["user-list", "invite", "debug", "login", "report-issue", "rooms", "call"] as const;
 export type Tab = (typeof SidebarTabs)[number];
 
 export enum ParticipantRole {

--- a/tauri/src/windows/main-window/app.tsx
+++ b/tauri/src/windows/main-window/app.tsx
@@ -182,6 +182,18 @@ function App() {
     return () => clearInterval(interval);
   }, []);
 
+  // Auto-navigate to the call page on call join, and away from it on call end.
+  const prevInCallRef = useRef(false);
+  useEffect(() => {
+    const inCall = !!callTokens;
+    if (inCall && !prevInCallRef.current) {
+      setTab("call");
+    } else if (!inCall && prevInCallRef.current && tab === "call") {
+      setTab("user-list");
+    }
+    prevInCallRef.current = inCall;
+  }, [callTokens, tab, setTab]);
+
   const handleReject = (isInCall?: boolean) => {
     const { incomingCallCallerId } = useStore.getState();
     if (!incomingCallCallerId && !isInCall) return;
@@ -455,7 +467,7 @@ function App() {
       <Sidebar />
       <ScrollArea type="scroll" className="h-100% overflow-y-scroll overflow-x-hidden w-[350px] relative h-full">
         {callTokens && (
-          <div className="sticky top-0 z-10 bg-white">
+          <div className={tab === "call" ? "" : "hidden"}>
             <CallCenter />
           </div>
         )}

--- a/tauri/src/windows/main-window/tabs/Rooms.tsx
+++ b/tauri/src/windows/main-window/tabs/Rooms.tsx
@@ -28,11 +28,9 @@ import { tauriUtils } from "@/windows/window-utils";
 import { useCallback, useEffect, useRef } from "react";
 import toast from "react-hot-toast";
 import { Button } from "@/components/ui/button";
-import { HiMiniLink, HiMiniUser } from "react-icons/hi2";
+import { HiMiniUser } from "react-icons/hi2";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { HiMagnifyingGlass, HiOutlinePencil, HiOutlineTrash } from "react-icons/hi2";
-import { writeText } from "@tauri-apps/plugin-clipboard-manager";
-import { Constants } from "@/constants";
 import { useState } from "react";
 import doorImage from "@/assets/door.png";
 import { useEndCall } from "@/lib/hooks";
@@ -85,7 +83,7 @@ const RoomPresenceAvatars = ({
                         alt={`${info.first_name} ${info.last_name}`}
                         className="size-full object-cover"
                       />
-                    : <span className="text-[8px] font-medium text-emerald-700">
+                      : <span className="text-[8px] font-medium text-emerald-700">
                         {info.first_name[0]}
                         {info.last_name[0]}
                       </span>
@@ -345,161 +343,156 @@ export const Rooms = () => {
     }
   }, [rooms, searchQuery]);
 
-  const isRoomCall = !(callTokens == null || !callTokens.room);
-
   return (
     <div className="flex flex-col items-start gap-1.5 p-2">
-      {isRoomCall && callTokens.room && <SelectedRoom room={callTokens.room} />}
-      {!isRoomCall && (
-        <div className="flex flex-col gap-2 w-full">
-          <div className="flex items-center gap-2 w-full">
-            <div className="relative flex-1">
-              <HiMagnifyingGlass className="absolute left-2 top-1/2 transform -translate-y-1/2 text-gray-500 size-4" />
-              <Input
-                type="text"
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search rooms"
-                className="pl-8 w-full focus-visible:ring-opacity-20 focus-visible:ring-2 focus-visible:ring-blue-300"
-              />
-            </div>
-            <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
-              <DialogTrigger asChild>
-                <Button variant="outline" size="icon">
-                  <Plus className="size-4 text-slate-500" />
-                </Button>
-              </DialogTrigger>
-              <DialogContent className="max-w-[80%]" container={document.getElementById("app-body")}>
-                <DialogHeader>
-                  <DialogTitle>Create new room</DialogTitle>
-                  <DialogDescription>Create a new room for your team to collaborate on.</DialogDescription>
-                </DialogHeader>
-                <div className="grid gap-3">
-                  <Label htmlFor="room-name">Room name</Label>
-                  <Input id="room-name" name="roomName" placeholder="Watercooler" />
-                </div>
-                <DialogDescription>Anyone in your team can modify or remove this room.</DialogDescription>
-                <DialogFooter>
-                  <DialogClose asChild>
-                    <Button
-                      onClick={() => {
-                        const input = document.getElementById("room-name") as HTMLInputElement;
-                        handleCreateRoom(input?.value || "");
-                        setIsCreateDialogOpen(false);
-                      }}
-                      className="text-xs"
-                    >
-                      Create room
-                    </Button>
-                  </DialogClose>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
+      <div className="flex flex-col gap-2 w-full">
+        <div className="flex items-center gap-2 w-full">
+          <div className="relative flex-1">
+            <HiMagnifyingGlass className="absolute left-2 top-1/2 transform -translate-y-1/2 text-gray-500 size-4" />
+            <Input
+              type="text"
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search rooms"
+              className="pl-8 w-full focus-visible:ring-opacity-20 focus-visible:ring-2 focus-visible:ring-blue-300"
+            />
           </div>
-          {filteredRooms && filteredRooms.length > 0 ?
-            <div className="grid grid-cols-2 gap-2 w-full">
-              {filteredRooms?.map((room) => {
-                const presenceIds = roomsPresence?.[room.id] ?? [];
-                return (
-                  <RoomButton
-                    key={room.id}
-                    onClick={() => handleJoinRoom(room)}
-                    disabled={!!callTokens?.isInitialisingCall || isJoiningRoom}
-                    size="unsized"
-                    title={room.name}
-                    className="flex-1 min-w-0 text-slate-600"
-                    presenceAvatars={
-                      presenceIds.length > 0 ?
-                        <RoomPresenceAvatars participantIds={presenceIds} getParticipantInfo={getParticipantInfo} />
-                      : undefined
-                    }
-                    cornerIcon={
-                      <DropdownMenu>
-                        <DropdownMenuTrigger className="hover:outline-solid hover:outline-1 hover:outline-slate-300 focus:ring-0 focus-visible:ring-0 hover:bg-slate-200 size-4 rounded-xs p-0 border-0 shadow-none hover:shadow-xs m-0 flex flex-row justify-center items-center">
-                          <MoreHorizontal className="size-3 m-0" />
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent className="muted" align="end">
-                          <DropdownMenuItem
-                            className="text-xs [&>svg]:size-3.5"
-                            onClick={() => {
-                              setSelectedRoom(room);
-                              setIsUpdateDialogOpen(true);
-                            }}
-                          >
-                            <HiOutlinePencil />
-                            Rename room
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            className="text-xs [&>svg]:size-3.5 text-red-600"
-                            onClick={() => {
-                              setSelectedRoom(room);
-                              setIsDeleteDialogOpen(true);
-                            }}
-                          >
-                            <HiOutlineTrash />
-                            Delete room
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    }
-                  />
-                );
-              })}
-            </div>
-          : <EmptyRoomsState onCreateRoomClick={() => setIsCreateDialogOpen(true)} isLoadingRooms={isLoadingRooms} />}
-          <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
-            <DialogContent container={document.getElementById("app-body")}>
+          <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+            <DialogTrigger asChild>
+              <Button variant="outline" size="icon">
+                <Plus className="size-4 text-slate-500" />
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-[80%]" container={document.getElementById("app-body")}>
               <DialogHeader>
-                <DialogTitle>Delete Room</DialogTitle>
-                <DialogDescription>
-                  Are you sure you want to delete this room? This action cannot be undone.
-                </DialogDescription>
+                <DialogTitle>Create new room</DialogTitle>
+                <DialogDescription>Create a new room for your team to collaborate on.</DialogDescription>
               </DialogHeader>
+              <div className="grid gap-3">
+                <Label htmlFor="room-name">Room name</Label>
+                <Input id="room-name" name="roomName" placeholder="Watercooler" />
+              </div>
+              <DialogDescription>Anyone in your team can modify or remove this room.</DialogDescription>
               <DialogFooter>
-                <Button
-                  variant="destructive"
-                  onClick={() => {
-                    // Handle delete logic here
-                    if (selectedRoom) {
-                      handleDeleteRoom(selectedRoom);
-                      setIsDeleteDialogOpen(false);
-                      setSelectedRoom(null);
-                    }
-                  }}
-                >
-                  Delete
-                </Button>
+                <DialogClose asChild>
+                  <Button
+                    onClick={() => {
+                      const input = document.getElementById("room-name") as HTMLInputElement;
+                      handleCreateRoom(input?.value || "");
+                      setIsCreateDialogOpen(false);
+                    }}
+                    className="text-xs"
+                  >
+                    Create room
+                  </Button>
+                </DialogClose>
               </DialogFooter>
             </DialogContent>
           </Dialog>
-          <Dialog open={isUpdateDialogOpen} onOpenChange={setIsUpdateDialogOpen}>
-            <DialogContent container={document.getElementById("app-body")}>
-              <form onSubmit={(e) => selectedRoom && handleUpdateRoom(selectedRoom, e)}>
-                <DialogHeader>
-                  <DialogTitle>Rename room</DialogTitle>
-                </DialogHeader>
-                <div className="grid gap-2">
-                  <Input
-                    id="room-name"
-                    name="name"
-                    className="text-xs text-slate-500"
-                    defaultValue={selectedRoom?.name}
-                  />
-                </div>
-                <DialogDescription className="mt-4 mb-2">
-                  Anyone in your team can modify or remove this room.
-                </DialogDescription>
-                <DialogFooter>
-                  <DialogClose asChild>
-                    <Button type="submit" className="text-xs">
-                      Update room
-                    </Button>
-                  </DialogClose>
-                </DialogFooter>
-              </form>
-            </DialogContent>
-          </Dialog>
         </div>
-      )}
+        {filteredRooms && filteredRooms.length > 0 ?
+          <div className="grid grid-cols-2 gap-2 w-full">
+            {filteredRooms?.map((room) => {
+              const presenceIds = roomsPresence?.[room.id] ?? [];
+              return (
+                <RoomButton
+                  key={room.id}
+                  onClick={() => handleJoinRoom(room)}
+                  disabled={!!callTokens?.isInitialisingCall || isJoiningRoom}
+                  size="unsized"
+                  title={room.name}
+                  className="flex-1 min-w-0 text-slate-600"
+                  presenceAvatars={
+                    presenceIds.length > 0 ?
+                      <RoomPresenceAvatars participantIds={presenceIds} getParticipantInfo={getParticipantInfo} />
+                      : undefined
+                  }
+                  cornerIcon={
+                    <DropdownMenu>
+                      <DropdownMenuTrigger className="hover:outline-solid hover:outline-1 hover:outline-slate-300 focus:ring-0 focus-visible:ring-0 hover:bg-slate-200 size-4 rounded-xs p-0 border-0 shadow-none hover:shadow-xs m-0 flex flex-row justify-center items-center">
+                        <MoreHorizontal className="size-3 m-0" />
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="muted" align="end">
+                        <DropdownMenuItem
+                          className="text-xs [&>svg]:size-3.5"
+                          onClick={() => {
+                            setSelectedRoom(room);
+                            setIsUpdateDialogOpen(true);
+                          }}
+                        >
+                          <HiOutlinePencil />
+                          Rename room
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="text-xs [&>svg]:size-3.5 text-red-600"
+                          onClick={() => {
+                            setSelectedRoom(room);
+                            setIsDeleteDialogOpen(true);
+                          }}
+                        >
+                          <HiOutlineTrash />
+                          Delete room
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  }
+                />
+              );
+            })}
+          </div>
+          : <EmptyRoomsState onCreateRoomClick={() => setIsCreateDialogOpen(true)} isLoadingRooms={isLoadingRooms} />}
+        <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+          <DialogContent container={document.getElementById("app-body")}>
+            <DialogHeader>
+              <DialogTitle>Delete Room</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to delete this room? This action cannot be undone.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  // Handle delete logic here
+                  if (selectedRoom) {
+                    handleDeleteRoom(selectedRoom);
+                    setIsDeleteDialogOpen(false);
+                    setSelectedRoom(null);
+                  }
+                }}
+              >
+                Delete
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+        <Dialog open={isUpdateDialogOpen} onOpenChange={setIsUpdateDialogOpen}>
+          <DialogContent container={document.getElementById("app-body")}>
+            <form onSubmit={(e) => selectedRoom && handleUpdateRoom(selectedRoom, e)}>
+              <DialogHeader>
+                <DialogTitle>Rename room</DialogTitle>
+              </DialogHeader>
+              <div className="grid gap-2">
+                <Input
+                  id="room-name"
+                  name="name"
+                  className="text-xs text-slate-500"
+                  defaultValue={selectedRoom?.name}
+                />
+              </div>
+              <DialogDescription className="mt-4 mb-2">
+                Anyone in your team can modify or remove this room.
+              </DialogDescription>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button type="submit" className="text-xs">
+                    Update room
+                  </Button>
+                </DialogClose>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
     </div>
   );
 };
@@ -530,35 +523,3 @@ const EmptyRoomsState = ({
   );
 };
 
-const SelectedRoom = ({ room }: { room: Room }) => {
-  const handleCopyRoomLink = async () => {
-    const roomLink = `${Constants.webAppUrl}/room/${room.id}`;
-    await writeText(roomLink);
-    toast.success("Room link copied to clipboard");
-  };
-
-  return (
-    <div className="flex flex-col w-full">
-      <div className="flex flex-row gap-2 justify-between items-center mb-4">
-        <div>
-          <h3 className="small">{room.name}</h3>
-        </div>
-        <div className="flex flex-row gap-2">
-          <Button variant="outline" size="icon-sm" onClick={handleCopyRoomLink}>
-            <TooltipProvider delayDuration={100}>
-              <Tooltip>
-                <TooltipTrigger>
-                  <HiMiniLink className="size-3.5" />
-                </TooltipTrigger>
-                <TooltipContent side="left" sideOffset={10} className="flex flex-col items-center gap-0">
-                  <span>Copy room link for web</span>
-                  <span className="text-xs text-slate-400">Share with teammates</span>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-};


### PR DESCRIPTION
Redesign call-center, as it was fixed on top and with more participants it was pushing the content down.

Also:
1. Fixed the macOS icon to be re-active based on if we are in a call or not.
2. Styled keyboard shortcuts


https://github.com/user-attachments/assets/ba075141-ba54-4149-aa43-417422dc372a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Call** tab in the sidebar with **Cmd+O / Ctrl+O** navigation.
  * Added **“Copy room link for web”** for room-based calls.
  * Automatically navigates to the Call view when a call starts, and returns when it ends.
* **Improvements**
  * Updated call UI shortcut styling and tooltip visuals for clearer keyboard hints.
  * Added a **transparent tooltip** appearance option for better visual consistency.
  * Expanded in-app keyboard shortcuts documentation for call viewing.
* **Bug Fixes**
  * Improved **macOS tray notification** updates so the notification dot reflects changes reliably.
* **Style**
  * Added global styling for `kbd` keyboard hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->