### PR TITLE
fix: room single user

### DIFF
--- a/backend/internal/callstate/callstate.go
+++ b/backend/internal/callstate/callstate.go
@@ -268,19 +268,22 @@ func (t *Tracker) MaterializeRoom(ctx context.Context, roomName string, members 
 }
 
 // RemoveUser removes a user from whatever room they're in, collapsing the room
-// if it becomes empty. Returns the room name and the remaining members.
-func (t *Tracker) RemoveUser(ctx context.Context, userID string) (string, []string, error) {
+// if it becomes empty. Returns the room name, the remaining members, and whether
+// the room is a named room (non-empty DisplayName => named/Slack room; empty =>
+// ad-hoc 1:1 call).
+func (t *Tracker) RemoveUser(ctx context.Context, userID string) (string, []string, bool, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	snap, err := t.readSnapshot(ctx)
 	if err != nil {
-		return "", nil, err
+		return "", nil, false, err
 	}
 	for roomName, room := range snap.Rooms {
 		if !slices.Contains(room.UserIDs, userID) {
 			continue
 		}
+		isNamedRoom := room.DisplayName != ""
 		remaining := slices.DeleteFunc(slices.Clone(room.UserIDs), func(p string) bool {
 			return p == userID
 		})
@@ -289,9 +292,9 @@ func (t *Tracker) RemoveUser(ctx context.Context, userID string) (string, []stri
 		} else {
 			snap.Rooms[roomName] = RoomPresence{DisplayName: room.DisplayName, UserIDs: remaining}
 		}
-		return roomName, remaining, t.writeSnapshot(ctx, snap)
+		return roomName, remaining, isNamedRoom, t.writeSnapshot(ctx, snap)
 	}
-	return "", nil, nil
+	return "", nil, false, nil
 }
 
 // StartReconciliation launches the background loop that reconciles the snapshot

--- a/backend/internal/callstate/callstate_test.go
+++ b/backend/internal/callstate/callstate_test.go
@@ -210,7 +210,7 @@ func TestRemoveUser(t *testing.T) {
 		_, err := tr.AddCallRoom(ctx, "room1", []string{"a", "b", "c"}, "")
 		require.NoError(t, err)
 
-		roomName, remaining, err := tr.RemoveUser(ctx, "b")
+		roomName, remaining, _, err := tr.RemoveUser(ctx, "b")
 		require.NoError(t, err)
 		assert.Equal(t, "room1", roomName)
 		assert.ElementsMatch(t, []string{"a", "c"}, remaining)
@@ -225,7 +225,7 @@ func TestRemoveUser(t *testing.T) {
 		_, err := tr.AddCallRoom(ctx, "room1", []string{"a"}, "")
 		require.NoError(t, err)
 
-		roomName, remaining, err := tr.RemoveUser(ctx, "a")
+		roomName, remaining, _, err := tr.RemoveUser(ctx, "a")
 		require.NoError(t, err)
 		assert.Equal(t, "room1", roomName)
 		assert.Empty(t, remaining)
@@ -237,7 +237,7 @@ func TestRemoveUser(t *testing.T) {
 	t.Run("noop for unknown user", func(t *testing.T) {
 		tr, _ := setupTracker(t)
 
-		roomName, remaining, err := tr.RemoveUser(ctx, "ghost")
+		roomName, remaining, _, err := tr.RemoveUser(ctx, "ghost")
 		require.NoError(t, err)
 		assert.Empty(t, roomName)
 		assert.Nil(t, remaining)
@@ -251,7 +251,7 @@ func TestRemoveUser(t *testing.T) {
 		_, err = tr.AddCallRoom(ctx, "room2", []string{"c", "d"}, "")
 		require.NoError(t, err)
 
-		_, _, err = tr.RemoveUser(ctx, "a")
+		_, _, _, err = tr.RemoveUser(ctx, "a")
 		require.NoError(t, err)
 
 		rooms := readSnapshotRooms(t, mr)
@@ -265,9 +265,9 @@ func TestRemoveUser(t *testing.T) {
 		_, err := tr.AddCallRoom(ctx, "room1", []string{"a", "b"}, "")
 		require.NoError(t, err)
 
-		_, _, err = tr.RemoveUser(ctx, "a")
+		_, _, _, err = tr.RemoveUser(ctx, "a")
 		require.NoError(t, err)
-		_, _, err = tr.RemoveUser(ctx, "b")
+		_, _, _, err = tr.RemoveUser(ctx, "b")
 		require.NoError(t, err)
 
 		rooms := readSnapshotRooms(t, mr)
@@ -373,7 +373,7 @@ func TestRoomCount(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 2, tr.RoomCount(ctx))
 
-		_, _, err = tr.RemoveUser(ctx, "a")
+		_, _, _, err = tr.RemoveUser(ctx, "a")
 		require.NoError(t, err)
 		assert.Equal(t, 1, tr.RoomCount(ctx))
 	})
@@ -408,7 +408,7 @@ func TestGetUserRoom(t *testing.T) {
 		_, err := tr.AddCallRoom(ctx, "room1", []string{"a", "b"}, "")
 		require.NoError(t, err)
 
-		_, _, err = tr.RemoveUser(ctx, "a")
+		_, _, _, err = tr.RemoveUser(ctx, "a")
 		require.NoError(t, err)
 
 		_, found, err := tr.GetUserRoom(ctx, "a")

--- a/backend/internal/handlers/slackHandlers.go
+++ b/backend/internal/handlers/slackHandlers.go
@@ -799,7 +799,7 @@ func (h *SlackHandler) LeaveRoom(c echo.Context) error {
 
 	if h.CallState != nil {
 		h.logger.Infof("callstate: RemoveUser userID=%s roomID=%s", user.ID, roomID)
-		if _, _, err := h.CallState.RemoveUser(c.Request().Context(), user.ID); err != nil {
+		if _, _, _, err := h.CallState.RemoveUser(c.Request().Context(), user.ID); err != nil {
 			h.logger.Warnf("callstate.RemoveUser error: %v", err)
 		}
 	}

--- a/backend/internal/handlers/websocketHandlers.go
+++ b/backend/internal/handlers/websocketHandlers.go
@@ -502,15 +502,16 @@ func endCall(ctx echo.Context, s *common.ServerState, userID string, message mes
 
 	if s.CallState != nil {
 		ctx.Logger().Infof("callstate: RemoveUser userID=%s", userID)
-		roomName, remainingPeers, err := s.CallState.RemoveUser(context.Background(), userID)
+		roomName, remainingPeers, isNamedRoom, err := s.CallState.RemoveUser(context.Background(), userID)
 		if err != nil {
 			ctx.Logger().Warnf("callstate.RemoveUser error: %v", err)
 		}
-		ctx.Logger().Infof("callstate: RemoveUser room=%s remainingPeers=%v", roomName, remainingPeers)
+		ctx.Logger().Infof("callstate: RemoveUser room=%s remainingPeers=%v isNamedRoom=%v", roomName, remainingPeers, isNamedRoom)
 
-		// Only notify when exactly one peer remains (last two in the call).
-		// Remove them too so the call is fully collapsed.
-		if len(remainingPeers) == 1 {
+		// Collapse ad-hoc 1:1 calls when exactly one peer remains (last two in the
+		// call): remove them too so the call is fully torn down. Named rooms are
+		// persistent meeting spots, so the remaining participant stays put.
+		if !isNamedRoom && len(remainingPeers) == 1 {
 			s.CallState.RemoveUser(context.Background(), remainingPeers[0])
 			endMsg := messages.NewCallEndMessage(userID)
 			endMsgJSON, mErr := json.Marshal(endMsg)


### PR DESCRIPTION
With this PR https://github.com/gethopp/hopp/pull/324 we introduced a bug where users if they were left alone alone in a room would be kick implicitly which shouldn't be the case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Named rooms now preserve remaining participants when users leave, while ad-hoc rooms continue to collapse as expected.

* **Tests**
  * Updated tests to reflect changes in room state tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->