### PR TITLE
fix: improve cpu usage when capturing

### DIFF
--- a/core/.cargo/config.toml
+++ b/core/.cargo/config.toml
@@ -1,8 +1,8 @@
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-args=-ObjC"]
+rustflags = ["-C", "link-args=-ObjC", "-C", "link-arg=-Wl,-rpath,/usr/lib/swift"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-args=-ObjC"]
+rustflags = ["-C", "link-args=-ObjC", "-C", "link-arg=-Wl,-rpath,/usr/lib/swift"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -212,6 +212,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
+name = "apple-cf"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7fd680cd0f3f02ee717b2014b26d18985c57b784384ba47213fcf8791e8c250"
+dependencies = [
+ "doom-fish-utils",
+]
+
+[[package]]
+name = "apple-metal"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b1c24b280fad9eadf6f2bf560d826392020ac6258b4c88c6dd356ae7a24f4e3"
+dependencies = [
+ "doom-fish-utils",
+ "libc",
+]
+
+[[package]]
 name = "approx"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1319,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1612,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "doom-fish-utils"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c801f6c2a0db1a1909d89fc395b9dccc594de9ef599659fbde9bb3b55ef67f9f"
+dependencies = [
+ "crossbeam-queue",
+ "futures-util",
 ]
 
 [[package]]
@@ -2616,6 +2654,7 @@ dependencies = [
  "resvg",
  "rodio",
  "rustfft",
+ "screencapturekit",
  "sentry_utils",
  "serde",
  "serde_json",
@@ -6209,6 +6248,15 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
+name = "screencapturekit"
+version = "7.0.1"
+source = "git+https://github.com/gethopp/screencapturekit-rs.git?branch=hopp#1dc01de57a950a3c122d311010f9d658b723bc48"
+dependencies = [
+ "apple-cf",
+ "apple-metal",
+]
 
 [[package]]
 name = "sctk-adwaita"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,7 +42,7 @@ windows = { version = "0.58.0", features = [
     ]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
-screencapturekit = "7.0.1"
+screencapturekit = { git = "https://github.com/gethopp/screencapturekit-rs.git", branch = "hopp" }
 core-graphics = { version = "0.25.0", features = ["highsierra"] }
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.7"
@@ -98,9 +98,3 @@ tract-onnx = "=0.21.4"
 tract-core = "=0.21.4"
 realfft = "3.4"
 rustfft = "6.2"
-
-[patch.crates-io]
-# Workaround: avoid duplicate Swift symbols from two modules named `CoreMediaBridge`
-# (one from `apple-cf`, one from `screencapturekit`) by renaming screencapturekit's
-# Swift target/module. See branch `hopp`.
-screencapturekit = { git = "https://github.com/gethopp/screencapturekit-rs.git", branch = "hopp" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,6 +42,7 @@ windows = { version = "0.58.0", features = [
     ]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
+screencapturekit = "7.0.1"
 core-graphics = { version = "0.25.0", features = ["highsierra"] }
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.7"
@@ -97,3 +98,9 @@ tract-onnx = "=0.21.4"
 tract-core = "=0.21.4"
 realfft = "3.4"
 rustfft = "6.2"
+
+[patch.crates-io]
+# Workaround: avoid duplicate Swift symbols from two modules named `CoreMediaBridge`
+# (one from `apple-cf`, one from `screencapturekit`) by renaming screencapturekit's
+# Swift target/module. See branch `hopp`.
+screencapturekit = { git = "https://github.com/gethopp/screencapturekit-rs.git", branch = "hopp" }

--- a/core/src/capture/capturer.rs
+++ b/core/src/capture/capturer.rs
@@ -33,7 +33,8 @@ pub enum MonitorId {
 use std::sync::{mpsc, Arc, Mutex};
 use std::vec;
 
-#[path = "stream.rs"]
+#[cfg_attr(target_os = "macos", path = "macos_stream.rs")]
+#[cfg_attr(not(target_os = "macos"), path = "stream.rs")]
 mod stream;
 use stream::{Stream, StreamRuntimeMessage};
 
@@ -512,15 +513,15 @@ impl Capturer {
         stream_resolution: Extent,
         include_cursor: bool,
         buffer_source: NativeVideoSource,
+        scale: f64,
     ) -> Result<(), CapturerError> {
-        log::info!("start_capture: content {content:?} resolution: {stream_resolution:?} include_cursor: {include_cursor}");
+        log::info!("start_capture: content {content:?} resolution: {stream_resolution:?} include_cursor: {include_cursor} scale: {scale}");
         if self.active_stream.is_some() {
             log::warn!("start_capture: active stream, stopping it");
             self.active_stream.as_mut().unwrap().stop_capture();
             self.active_stream = None;
         }
 
-        let scale = 1.0;
         let mut stream = Stream::new(
             stream_resolution,
             scale,

--- a/core/src/capture/macos_stream.rs
+++ b/core/src/capture/macos_stream.rs
@@ -1,0 +1,293 @@
+use crate::utils::geometry::{aspect_fit, Extent, Frame};
+use livekit::webrtc::{
+    prelude::{NV12Buffer, VideoFrame, VideoRotation},
+    video_source::native::NativeVideoSource,
+};
+use screencapturekit::{
+    cm::{CMSampleBufferExt, CMSampleBufferSCExt, IOSurfaceLockOptions},
+    prelude::*,
+    stream::delegate_trait::StreamCallbacks,
+};
+use std::sync::{mpsc, Arc, Mutex};
+
+use super::CapturerError;
+
+#[allow(dead_code)]
+pub enum StreamRuntimeMessage {
+    Failed,
+    Stop,
+    StopCapture,
+    UserStoppedCapture,
+}
+
+struct StreamBuffer {
+    video_frame: VideoFrame<NV12Buffer>,
+}
+
+impl StreamBuffer {
+    pub fn new(width: u32, height: u32) -> Self {
+        let video_frame = VideoFrame {
+            rotation: VideoRotation::VideoRotation0,
+            buffer: NV12Buffer::new(width, height),
+            timestamp_us: 0,
+        };
+        StreamBuffer { video_frame }
+    }
+}
+
+pub struct Stream {
+    sc_stream: Option<SCStream>,
+    permanent_error_tx: mpsc::Sender<StreamRuntimeMessage>,
+    stream_buffer: Arc<Mutex<StreamBuffer>>,
+    buffer_source: NativeVideoSource,
+    frame: Arc<Mutex<Frame>>,
+    stream_resolution: Extent,
+    source_id: u32,
+    failures_count: Arc<Mutex<u64>>,
+    include_cursor: bool,
+    output_extent: Arc<Mutex<Extent>>,
+    scale: f64,
+}
+
+impl Stream {
+    pub fn new(
+        stream_resolution: Extent,
+        scale: f64,
+        tx: mpsc::Sender<StreamRuntimeMessage>,
+        include_cursor: bool,
+        buffer_source: NativeVideoSource,
+    ) -> Result<Self, CapturerError> {
+        Ok(Stream {
+            sc_stream: None,
+            permanent_error_tx: tx,
+            stream_buffer: Arc::new(Mutex::new(StreamBuffer::new(1, 1))),
+            buffer_source,
+            frame: Arc::new(Mutex::new(Frame::default())),
+            stream_resolution,
+            source_id: 0,
+            failures_count: Arc::new(Mutex::new(0)),
+            include_cursor,
+            output_extent: Arc::new(Mutex::new(Extent {
+                width: 0.,
+                height: 0.,
+            })),
+            scale,
+        })
+    }
+
+    pub fn start_capture(&mut self, id: u32) -> Result<(), CapturerError> {
+        log::info!("macos_stream::start_capture: Starting capture for id: {id}");
+
+        let content = SCShareableContent::get().map_err(|e| {
+            log::error!("start_capture: Failed to get shareable content: {e}");
+            CapturerError::DesktopCapturerCreationError
+        })?;
+
+        let displays = content.displays();
+        if displays.is_empty() {
+            return Err(CapturerError::CaptureSourceListEmpty);
+        }
+
+        let display = displays
+            .into_iter()
+            .find(|d| d.display_id() == id)
+            .ok_or(CapturerError::SelectedSourceNotFound)?;
+
+        let native_width = (display.width() as f64 * self.scale) as u32;
+        let native_height = (display.height() as f64 * self.scale) as u32;
+        let (stream_width, stream_height) = aspect_fit(
+            native_width,
+            native_height,
+            self.stream_resolution.width as u32,
+            self.stream_resolution.height as u32,
+        );
+        log::info!(
+            "start_capture: output {stream_width}x{stream_height} from display {native_width}x{native_height} (scale: {})",
+            self.scale
+        );
+
+        {
+            let mut extent = self.output_extent.lock().unwrap();
+            extent.width = stream_width as f64;
+            extent.height = stream_height as f64;
+        }
+        {
+            let mut sb = self.stream_buffer.lock().unwrap();
+            *sb = StreamBuffer::new(stream_width, stream_height);
+        }
+
+        let config = SCStreamConfiguration::new()
+            .with_width(stream_width)
+            .with_height(stream_height)
+            .with_pixel_format(PixelFormat::YCbCr_420v)
+            .with_shows_cursor(self.include_cursor)
+            .with_fps(60);
+
+        let filter = SCContentFilter::create()
+            .with_display(&display)
+            .with_excluding_windows(&[])
+            .build();
+
+        let error_tx = self.permanent_error_tx.clone();
+        let stop_tx = self.permanent_error_tx.clone();
+        let error_failures_count = self.failures_count.clone();
+        let delegate = StreamCallbacks::new()
+            .on_error(move |error| {
+                log::error!("SCStream error: {error}");
+                *error_failures_count.lock().unwrap() += 1;
+                let _ = error_tx.send(StreamRuntimeMessage::Failed);
+            })
+            .on_stop(move |error| {
+                if let Some(msg) = error {
+                    log::info!("SCStream stopped with error: {msg}");
+                    let _ = stop_tx.send(StreamRuntimeMessage::UserStoppedCapture);
+                }
+            });
+
+        let stream_buffer = self.stream_buffer.clone();
+        let buffer_source = self.buffer_source.clone();
+        let failures_count = self.failures_count.clone();
+        let frame_arc = self.frame.clone();
+        let capture_start = std::time::Instant::now();
+
+        let handler = move |sample: CMSampleBuffer, of_type: SCStreamOutputType| {
+            if !matches!(of_type, SCStreamOutputType::Screen) {
+                return;
+            }
+
+            {
+                *failures_count.lock().unwrap() = 0;
+            }
+
+            let pixel_buffer = match sample.image_buffer() {
+                Some(pb) => pb,
+                None => return,
+            };
+
+            let io_surface = match pixel_buffer.io_surface() {
+                Some(s) => s,
+                None => {
+                    log::warn!("start_capture handler: frame not IOSurface-backed");
+                    return;
+                }
+            };
+
+            let guard = match io_surface.lock(IOSurfaceLockOptions::READ_ONLY) {
+                Ok(g) => g,
+                Err(e) => {
+                    log::warn!("start_capture handler: IOSurface lock failed: {e}");
+                    return;
+                }
+            };
+
+            let src_y = match guard.plane_data(0) {
+                Some(d) => d,
+                None => return,
+            };
+            let src_uv = match guard.plane_data(1) {
+                Some(d) => d,
+                None => return,
+            };
+
+            let src_stride_y = io_surface.bytes_per_row_of_plane(0);
+            let src_stride_uv = io_surface.bytes_per_row_of_plane(1);
+            let frame_width = io_surface.width_of_plane(0);
+            let frame_height = io_surface.height_of_plane(0);
+
+            if frame_width == 0 || frame_height == 0 {
+                return;
+            }
+
+            // Update frame metadata
+            {
+                if let Some(content_rect) = sample.content_rect() {
+                    let mut frame = frame_arc.lock().unwrap();
+                    frame.origin_x = content_rect.origin.x;
+                    frame.origin_y = content_rect.origin.y;
+                    frame.extent.width = content_rect.size.width;
+                    frame.extent.height = content_rect.size.height;
+                }
+            }
+
+            let mut sb = stream_buffer.lock().unwrap();
+            let (dst_stride_y, dst_stride_uv) = sb.video_frame.buffer.strides();
+            let (dst_y, dst_uv) = sb.video_frame.buffer.data_mut();
+
+            // Copy Y plane row-by-row to handle stride mismatch
+            let copy_width_y = frame_width.min(dst_stride_y as usize);
+            for row in 0..frame_height {
+                let src_off = row * src_stride_y;
+                let dst_off = row * dst_stride_y as usize;
+                dst_y[dst_off..dst_off + copy_width_y]
+                    .copy_from_slice(&src_y[src_off..src_off + copy_width_y]);
+            }
+
+            // Copy UV plane (half height, interleaved CbCr)
+            let uv_height = frame_height / 2;
+            let copy_width_uv = (frame_width).min(dst_stride_uv as usize);
+            for row in 0..uv_height {
+                let src_off = row * src_stride_uv;
+                let dst_off = row * dst_stride_uv as usize;
+                dst_uv[dst_off..dst_off + copy_width_uv]
+                    .copy_from_slice(&src_uv[src_off..src_off + copy_width_uv]);
+            }
+
+            sb.video_frame.timestamp_us = capture_start.elapsed().as_micros() as i64;
+            buffer_source.capture_frame(&sb.video_frame);
+        };
+
+        let mut sc_stream = SCStream::new_with_delegate(&filter, &config, delegate);
+        sc_stream.add_output_handler(handler, SCStreamOutputType::Screen);
+
+        sc_stream.start_capture().map_err(|e| {
+            log::error!("start_capture: SCK start_capture failed: {e}");
+            CapturerError::DesktopCapturerCreationError
+        })?;
+
+        self.sc_stream = Some(sc_stream);
+        self.source_id = id;
+        Ok(())
+    }
+
+    pub fn stop_capture(&mut self) {
+        if let Some(ref stream) = self.sc_stream {
+            if let Err(e) = stream.stop_capture() {
+                log::warn!("stop_capture: SCK stop error: {e}");
+            }
+        }
+        self.sc_stream = None;
+    }
+
+    pub fn copy(mut self) -> Result<Self, ()> {
+        if self.sc_stream.is_some() {
+            log::warn!("Stream::copy: Stream is running, stopping it");
+            self.stop_capture();
+        }
+
+        Ok(Stream {
+            sc_stream: None,
+            permanent_error_tx: self.permanent_error_tx.clone(),
+            stream_buffer: self.stream_buffer.clone(),
+            buffer_source: self.buffer_source.clone(),
+            frame: self.frame.clone(),
+            stream_resolution: self.stream_resolution,
+            source_id: self.source_id,
+            failures_count: self.failures_count.clone(),
+            include_cursor: self.include_cursor,
+            output_extent: self.output_extent.clone(),
+            scale: self.scale,
+        })
+    }
+
+    pub fn get_failures_count(&self) -> u64 {
+        *self.failures_count.lock().unwrap()
+    }
+
+    pub fn source_id(&self) -> u32 {
+        self.source_id
+    }
+
+    pub fn get_stream_extent(&self) -> Extent {
+        *self.output_extent.lock().unwrap()
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -406,6 +406,9 @@ impl<'a> Application<'a> {
             }
         };
 
+        let monitor = screen_capturer.get_selected_monitor(&monitors, screenshare_input.content.id);
+        let scale = monitor.scale_factor();
+
         let res = screen_capturer.start_capture(
             screenshare_input.content,
             Extent {
@@ -414,6 +417,7 @@ impl<'a> Application<'a> {
             },
             !screenshare_input.accessibility_permission,
             buffer_source,
+            scale,
         );
         if let Err(error) = res {
             log::error!("screenshare: error starting capture: {error:?}");
@@ -430,7 +434,6 @@ impl<'a> Application<'a> {
         room_service.unmute_screen_share_track();
         log::info!("screenshare: screen share track unmuted");
 
-        let monitor = screen_capturer.get_selected_monitor(&monitors, screenshare_input.content.id);
         drop(screen_capturer);
 
         let res = self.create_overlay_window(


### PR DESCRIPTION
Changes the capturing library on macos from libwebrtc to screencapturekit-rs. This reduces significant the cpu usage because we are not converting from rgb to nv12, and we are not scaling the framebuffer to the target res. Both of those are set as the capturing configuration. Also the frame is captured from a callback and not by polling, which reduces cpu usage and the latency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS screen capture via ScreenCaptureKit, with support for per-display scale factors to improve captured output sizing.
* **Bug Fixes**
  * Updated screensharing flow to determine the selected monitor and its scale before starting capture, ensuring the correct scaling is applied.
* **Configuration**
  * Adjusted macOS Rust linker settings to include the Swift library runtime search path.
* **Dependencies**
  * Added macOS-specific screencapturekit support for native capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->