### PR TITLE
feat: move noise cancellation to settings page

### DIFF
--- a/tauri/src-tauri/src/app_state.rs
+++ b/tauri/src-tauri/src/app_state.rs
@@ -9,6 +9,8 @@ pub struct UserSettings {
     pub show_dock_icon_in_call: bool,
     pub start_camera_on_call: bool,
     pub start_mic_on_call: bool,
+    #[serde(default = "default_noise_cancellation_enabled")]
+    pub noise_cancellation_enabled: bool,
     pub hopp_server_url: Option<String>,
     pub shortcut_toggle_mic: Option<String>,
     pub shortcut_toggle_camera: Option<String>,
@@ -23,6 +25,7 @@ impl Default for UserSettings {
             show_dock_icon_in_call: true,
             start_camera_on_call: false,
             start_mic_on_call: true,
+            noise_cancellation_enabled: true,
             hopp_server_url: None,
             shortcut_toggle_mic: None,
             shortcut_toggle_camera: None,
@@ -30,6 +33,10 @@ impl Default for UserSettings {
             shortcut_end_call: None,
         }
     }
+}
+
+fn default_noise_cancellation_enabled() -> bool {
+    true
 }
 
 #[cfg(target_os = "macos")]

--- a/tauri/src-tauri/src/lib.rs
+++ b/tauri/src-tauri/src/lib.rs
@@ -83,9 +83,6 @@ pub struct AppData {
     /// Suppresses main window hide when activation policy is switched to Accessory after a call ends.
     pub suppress_hide_on_call_end: Arc<AtomicBool>,
 
-    /// Whether noise cancellation is enabled (synced with core process).
-    pub noise_cancellation_enabled: bool,
-
     /// Whether drawing mode is currently enabled (runtime state).
     pub drawing_enabled: bool,
 
@@ -132,7 +129,6 @@ impl AppData {
             #[cfg(target_os = "macos")]
             activation_policy_regular: false,
             suppress_hide_on_call_end,
-            noise_cancellation_enabled: true,
             drawing_enabled: false,
             call_active: false,
             is_camera_on: false,

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -968,17 +968,11 @@ fn toggle_mic(app: tauri::AppHandle) {
 fn set_noise_cancellation(app: tauri::AppHandle, enabled: bool) {
     let data = app.state::<Mutex<AppData>>();
     let mut data = data.lock().unwrap();
-    data.noise_cancellation_enabled = enabled;
+    data.app_state
+        .update_user_setting(|settings| settings.noise_cancellation_enabled = enabled);
     if let Err(e) = data.sender.send(Message::SetNoiseCancellation(enabled)) {
         log::error!("set_noise_cancellation: failed to send: {e:?}");
     }
-}
-
-#[tauri::command(async)]
-fn get_noise_cancellation(app: tauri::AppHandle) -> bool {
-    let data = app.state::<Mutex<AppData>>();
-    let data = data.lock().unwrap();
-    data.noise_cancellation_enabled
 }
 
 #[tauri::command(async)]
@@ -1449,6 +1443,10 @@ fn main() {
             let core_events_rx = event_socket.take_events();
 
             let app_state = AppState::new(&app_data_dir);
+            let noise_cancellation_enabled = app_state.user_settings().noise_cancellation_enabled;
+            if let Err(e) = sender.send(Message::SetNoiseCancellation(noise_cancellation_enabled)) {
+                log::error!("Failed to send initial noise_cancellation_enabled: {e:?}");
+            }
             if let Err(e) = sender.send(Message::ControllerDrawPersistChanged(app_state.controller_draw_persist())) {
                 log::error!("Failed to send initial controller_draw_persist: {e:?}");
             }
@@ -1766,7 +1764,6 @@ fn main() {
             unmute_mic,
             toggle_mic,
             set_noise_cancellation,
-            get_noise_cancellation,
             list_microphones,
             select_microphone,
             list_webcams,

--- a/tauri/src/core_payloads.ts
+++ b/tauri/src/core_payloads.ts
@@ -117,6 +117,7 @@ export interface UserSettings {
   show_dock_icon_in_call: boolean;
   start_camera_on_call: boolean;
   start_mic_on_call: boolean;
+  noise_cancellation_enabled: boolean;
   hopp_server_url: string | null;
   shortcut_toggle_mic: string;
   shortcut_toggle_camera: string;
@@ -238,7 +239,6 @@ export interface CommandMap {
   unmute_mic: { args: void; return: void };
   toggle_mic: { args: void; return: void };
   set_noise_cancellation: { args: { enabled: boolean }; return: void };
-  get_noise_cancellation: { args: void; return: boolean };
   list_microphones: { args: void; return: AudioDevice[] };
   select_microphone: { args: { deviceName: string }; return: void };
 

--- a/tauri/src/windows/main-window/tabs/Debug.tsx
+++ b/tauri/src/windows/main-window/tabs/Debug.tsx
@@ -1,6 +1,5 @@
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import useStore from "@/store/store";
 import { socketService } from "@/services/socket";
 import { Button } from "@/components/ui/button";
@@ -16,7 +15,6 @@ export const Debug = () => {
   const { callTokens, setCallTokens, authToken } = useStore();
   const [isPlaying, setIsPlaying] = useState(false);
   const [trayNotification, setTrayNotification] = useState(false);
-  const [noiseCancellation, setNoiseCancellation] = useState(true);
   const soundRef = useRef(soundUtils.createPlayer("incoming-call"));
 
   const { refetch, data, isLoading, isFetching } = useQuery({
@@ -33,10 +31,6 @@ export const Debug = () => {
       console.error("Failed to set tray notification:", error);
     }
   };
-
-  useEffect(() => {
-    typedInvoke("get_noise_cancellation").then(setNoiseCancellation);
-  }, []);
 
   useEffect(() => {
     return () => {
@@ -131,26 +125,6 @@ export const Debug = () => {
         <Button onClick={() => typedInvoke("open_stats_window")} size="sm">
           Open Stats Window
         </Button>
-      </div>
-
-      <div className="flex flex-col gap-3 my-4 p-3 border rounded-lg bg-gray-50 dark:bg-gray-800">
-        <Label className="text-sm font-medium">App Settings</Label>
-        <div className="flex items-center justify-between">
-          <div className="flex flex-col gap-0.5">
-            <Label htmlFor="noise-cancellation" className="text-sm">
-              Noise Cancellation
-            </Label>
-            <span className="text-xs text-muted-foreground">Noise suppression on microphone input</span>
-          </div>
-          <Switch
-            id="noise-cancellation"
-            checked={noiseCancellation}
-            onCheckedChange={(checked) => {
-              setNoiseCancellation(checked);
-              typedInvoke("set_noise_cancellation", { enabled: checked });
-            }}
-          />
-        </div>
       </div>
 
       <div className="flex flex-col gap-3 my-4 p-3 border rounded-lg bg-gray-50 dark:bg-gray-800">

--- a/tauri/src/windows/settings/main.tsx
+++ b/tauri/src/windows/settings/main.tsx
@@ -144,12 +144,6 @@ function SettingsWindow() {
     refetchOnWindowFocus: true,
   });
 
-  const { data: noiseCancellation, refetch: refetchNoiseCancellation } = useQuery({
-    queryKey: ["noise-cancellation"],
-    queryFn: () => typedInvoke("get_noise_cancellation"),
-    refetchOnWindowFocus: true,
-  });
-
   useEffect(() => {
     if (settings) {
       setServerUrl(settings.hopp_server_url ?? "");
@@ -246,9 +240,9 @@ function SettingsWindow() {
               <CheckboxRow
                 title="Noise cancellation"
                 description="Noise suppression on microphone input"
-                checked={noiseCancellation ?? true}
+                checked={settings.noise_cancellation_enabled}
                 onCheckedChange={(v) => {
-                  typedInvoke("set_noise_cancellation", { enabled: v }).then(() => refetchNoiseCancellation());
+                  typedInvoke("set_noise_cancellation", { enabled: v }).then(() => refetchSettings());
                 }}
               />
             </div>

--- a/tauri/src/windows/settings/main.tsx
+++ b/tauri/src/windows/settings/main.tsx
@@ -144,6 +144,12 @@ function SettingsWindow() {
     refetchOnWindowFocus: true,
   });
 
+  const { data: noiseCancellation, refetch: refetchNoiseCancellation } = useQuery({
+    queryKey: ["noise-cancellation"],
+    queryFn: () => typedInvoke("get_noise_cancellation"),
+    refetchOnWindowFocus: true,
+  });
+
   useEffect(() => {
     if (settings) {
       setServerUrl(settings.hopp_server_url ?? "");
@@ -235,6 +241,14 @@ function SettingsWindow() {
                 checked={settings.start_mic_on_call}
                 onCheckedChange={(v) => {
                   typedInvoke("set_start_mic_on_call", { enabled: v }).then(() => refetchSettings());
+                }}
+              />
+              <CheckboxRow
+                title="Noise cancellation"
+                description="Noise suppression on microphone input"
+                checked={noiseCancellation ?? true}
+                onCheckedChange={(v) => {
+                  typedInvoke("set_noise_cancellation", { enabled: v }).then(() => refetchNoiseCancellation());
                 }}
               />
             </div>

--- a/tauri/src/windows/window-utils.ts
+++ b/tauri/src/windows/window-utils.ts
@@ -341,6 +341,7 @@ const getUserSettings = async () => {
     show_dock_icon_in_call: boolean;
     start_camera_on_call: boolean;
     start_mic_on_call: boolean;
+    noise_cancellation_enabled: boolean;
     hopp_server_url: string | null;
   }>("get_user_settings");
 };


### PR DESCRIPTION
Moved noise cancellation to settings page, removed from debug page
closes #340 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Moved the noise-cancellation control out of the Debug window.
  * Added a **Noise cancellation** checkbox under **Settings → Audio**, tied to saved user preferences.

* **Behavior Changes**
  * Noise-cancellation is applied immediately at startup based on the saved setting.
  * Debug no longer exposes a direct control for noise-cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->