### PR TITLE
chore: remove obsolete 30-day free trial

### DIFF
--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -298,12 +298,7 @@ func GetUserWithSubscription(db *gorm.DB, user *User, stripeEnabled bool) (*User
 		return &UserWithSubscription{User: *user, IsPro: true}, nil
 	}
 
-	// Teams created before 2026-05-04 keep legacy 30-day trial; new teams get 14 days.
-	trialCutoff := time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC)
-	trialDays := 14
-	if team.CreatedAt.Before(trialCutoff) {
-		trialDays = 30
-	}
+	const trialDays = 14
 	trialEndsAt := team.CreatedAt.AddDate(0, 0, trialDays)
 	return &UserWithSubscription{
 		User:        *user,

--- a/backend/web/emails/hopp-welcome.html
+++ b/backend/web/emails/hopp-welcome.html
@@ -173,7 +173,7 @@
               <!-- -->{first_name}<!-- -->,
             </p>
             <p style="font-size: 14px; color: rgb(0, 0, 0); line-height: 24px; margin-top: 16px; margin-bottom: 16px">
-              <b>Your 30-day trial starts now!</b> Start inviting your team members to join your workspace and start
+              <b>Your 14-day trial starts now!</b> Start inviting your team members to join your workspace and start
               collaborating seamlessly.
             </p>
             <table

--- a/tauri/src/components/sidebar/Sidebar.tsx
+++ b/tauri/src/components/sidebar/Sidebar.tsx
@@ -71,7 +71,7 @@ const getAvailableTabs = (
           key: "login",
         } as const,
       ]
-      : [
+    : [
         {
           label: "User List",
           icon: <HiOutlineUsers className="size-4 stroke-[1.5]" />,
@@ -131,7 +131,7 @@ const DownloadNewVersionButton = () => {
         >
           {updateInProgress ?
             <CgSpinner className="animate-spin size-3.5 text-gray-800" />
-            : <LuCircleFadingArrowUp className="size-3.5 text-gray-800" />}
+          : <LuCircleFadingArrowUp className="size-3.5 text-gray-800" />}
         </button>
       </TooltipTrigger>
       <TooltipContent side="right">Download and install update</TooltipContent>
@@ -154,18 +154,13 @@ const TrialCountdownAvatarFill = ({ user }: { user: components["schemas"]["Priva
   const isExpired = daysRemaining <= 0;
   const displayDays = Math.max(0, daysRemaining);
 
-  // teams created before 2026-05-04 keep 30-day trial; new teams get 14.
-  const TRIAL_GRANDFATHER_CUTOFF = new Date("2026-05-04T00:00:00Z");
-  const userCreatedAt = user.created_at ? parseISO(user.created_at) : new Date();
-  const maxTrialDays = userCreatedAt < TRIAL_GRANDFATHER_CUTOFF ? 30 : 14;
+  const maxTrialDays = 14;
   const percentage = isExpired ? 100 : Math.min(100, Math.max(5, (daysRemaining / maxTrialDays) * 100));
 
-  // Thresholds scale with maxTrialDays so bar starts green for both 14- and 30-day trials.
-  // 30-day: yellow ≤14, orange ≤7, red ≤3 (matches prior behavior).
-  // 14-day: yellow ≤7,  orange ≤3, red ≤1.
-  const yellowAt = Math.ceil(maxTrialDays / 2);
-  const orangeAt = Math.ceil(maxTrialDays / 4);
-  const redAt = Math.max(3, Math.floor(maxTrialDays / 10));
+  // 14-day trial thresholds: yellow ≤7, orange ≤3, red ≤1.
+  const yellowAt = 7;
+  const orangeAt = 3;
+  const redAt = 1;
 
   const getTextColor = (days: number) => {
     if (days <= redAt) return "text-red-800";
@@ -226,7 +221,7 @@ const TrialCountdownAvatarFill = ({ user }: { user: components["schemas"]["Priva
         <TooltipContent side="right">
           {isExpired ?
             "Trial expired, click to manage subscription"
-            : `Trial expires in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}, click to manage`}
+          : `Trial expires in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}, click to manage`}
         </TooltipContent>
       </Tooltip>
     </div>
@@ -267,7 +262,9 @@ const CallPageButton = () => {
           <FiPhoneCall className="size-4 text-green-500" />
         </button>
       </TooltipTrigger>
-      <TooltipContent side="right" className="flex flex-row items-center">Ongoing call <kbd className="max-w-min text-xs leading-3">{shortcutLabel}</kbd></TooltipContent>
+      <TooltipContent side="right" className="flex flex-row items-center">
+        Ongoing call <kbd className="max-w-min text-xs leading-3">{shortcutLabel}</kbd>
+      </TooltipContent>
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Summary
- Consolidate all teams onto a single 14-day trial; remove the 30-day grandfathering for teams created before 2026-05-04 (those trials have all expired).
- Backend: `GetUserWithSubscription` now uses a flat `trialDays = 14` in `backend/internal/models/user.go`.
- Desktop UI: `TrialCountdownAvatarFill` hardcodes `maxTrialDays = 14` with fixed color thresholds (yellow <=7, orange <=3, red <=1) in `tauri/src/components/sidebar/Sidebar.tsx`.
- Email: welcome email copy updated to "Your 14-day trial starts now!" in `backend/web/emails/hopp-welcome.html`.

## Test plan
- [ ] New team's `trial_ends_at` is 14 days after team creation.
- [ ] Sidebar trial countdown bar shows correct color transitions for a 14-day trial.
- [ ] Welcome email renders the 14-day copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Trial period standardized to 14 days for all new teams
  * Welcome email updated to reflect new trial duration
  * Trial countdown indicator now displays color-coded alerts at 7, 3, and 1 days remaining

<!-- end of auto-generated comment: release notes by coderabbit.ai -->