### PR TITLE
feat: join a room from the contact list

### DIFF
--- a/tauri/src/components/ui/participant-row-wo-livekit.tsx
+++ b/tauri/src/components/ui/participant-row-wo-livekit.tsx
@@ -14,6 +14,7 @@ import { HoppAvatar } from "@/components/ui/hopp-avatar";
 import { tauriUtils } from "@/windows/window-utils";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAPI } from "@/services/query";
+import { useEndCall } from "@/lib/hooks";
 
 const TruncatedName = ({ text, className }: { text: string; className?: string }) => {
   const textRef = useRef<HTMLDivElement>(null);
@@ -52,10 +53,13 @@ const TruncatedName = ({ text, className }: { text: string; className?: string }
   );
 };
 
-export const ParticipantRow = (props: { user: components["schemas"]["BaseUser"] }) => {
+export const ParticipantRow = (props: {
+  user: components["schemas"]["BaseUser"];
+  rooms: components["schemas"]["Room"][];
+}) => {
   const posthog = usePostHog();
   const isCalling = useStore((state) => state.calling === props.user.id);
-  const { setCalling, setCallTokens } = useStore((state) => state);
+  const { setCalling, callTokens, setCallTokens } = useStore((state) => state);
   const inACall = useStore((state) => state.callTokens !== null);
   const hasIncomingCall = useStore((state) => state.incomingCallCallerId !== null);
   const callsPresence = useStore((state) => state.callsPresence);
@@ -77,6 +81,83 @@ export const ParticipantRow = (props: { user: components["schemas"]["BaseUser"] 
 
   const { useMutation } = useAPI();
   const { mutateAsync: joinCallRequest } = useMutation("post", "/api/auth/call/join/{userId}", undefined);
+  const { mutateAsync: getRoomTokens } = useMutation("get", "/api/auth/room/{id}", undefined);
+
+  const targetRoom = useMemo(
+    () => props.rooms.find((r) => r.name === userPresence?.roomName),
+    [props.rooms, userPresence?.roomName],
+  );
+  const isJoiningRoom = useRef(false);
+  const endCall = useEndCall();
+
+  const joinRoom = useCallback(async () => {
+    if (!targetRoom || isJoiningRoom.current) return;
+
+    isJoiningRoom.current = true;
+    try {
+      posthog.capture("user_join_room", {
+        user_id: props.user.id,
+        user_name: props.user.first_name,
+        room_id: targetRoom.id,
+        room_name: targetRoom.name,
+      });
+
+      if (callTokens) {
+        endCall();
+        await sleep(500);
+      }
+
+      const tokens = await getRoomTokens({
+        params: { path: { id: targetRoom.id } },
+      });
+
+      if (!tokens) {
+        toast.error("Error joining room");
+        return;
+      }
+
+      sounds.callAccepted.play();
+      let startMic = false;
+      let startCamera = false;
+      try {
+        const settings = await tauriUtils.getUserSettings();
+        startMic = settings.start_mic_on_call;
+        startCamera = settings.start_camera_on_call;
+      } catch {
+        // fall back to safe defaults
+      }
+      setCallTokens({
+        ...tokens,
+        isRoomCall: true,
+        timeStarted: new Date(),
+        hasAudioEnabled: startMic,
+        hasCameraEnabled: startCamera,
+        role: ParticipantRole.NONE,
+        isRemoteControlEnabled: true,
+        room: targetRoom,
+        participants: [],
+        isInitialisingCall: true,
+        micLevel: 0,
+      });
+
+      try {
+        await tauriUtils.callStarted(tokens.audioToken, tokens.videoToken);
+      } catch {
+        setCallTokens(null);
+        toast.error("Failed to start call");
+        return;
+      }
+      tauriUtils.showWindow("main");
+    } catch (error: any) {
+      if (error?.error === "trial-ended") {
+        toast.error("Trial has expired, contact us if you want to extend it");
+      } else {
+        toast.error("Error joining room");
+      }
+    } finally {
+      isJoiningRoom.current = false;
+    }
+  }, [targetRoom, callTokens, props.user, setCallTokens, endCall, getRoomTokens, posthog]);
 
   const callbackIdRef = useRef<string>(`call-response-${props.user.id}`);
   const callResolvedRef = useRef(false);
@@ -323,7 +404,17 @@ export const ParticipantRow = (props: { user: components["schemas"]["BaseUser"] 
       </div>
 
       <div className="mr-4">
-        {userPresence && !userPresence.roomName && !inACall ?
+        {userPresence?.roomName && !inACall ?
+          <Button
+            variant="gradient-white"
+            onClick={joinRoom}
+            disabled={!targetRoom || isJoiningRoom.current}
+            className="px-2 w-auto h-7 flex flex-row items-center gap-1 text-slate-600"
+          >
+            <HiPhoneArrowDownLeft className="size-3" />
+            Join
+          </Button>
+        : userPresence && !userPresence.roomName && !inACall ?
           <Button
             variant="gradient-white"
             onClick={joinCall}
@@ -348,7 +439,7 @@ export const ParticipantRow = (props: { user: components["schemas"]["BaseUser"] 
                 callUser();
               }
             }}
-            disabled={inACall || hasIncomingCall || !!userPresence}
+            disabled={inACall || hasIncomingCall}
             className={clsx(
               "px-2 w-auto h-7 flex flex-row items-center gap-1",
               !isCalling && "text-slate-600",

--- a/tauri/src/components/ui/participant-row-wo-livekit.tsx
+++ b/tauri/src/components/ui/participant-row-wo-livekit.tsx
@@ -84,6 +84,7 @@ export const ParticipantRow = (props: {
   const { mutateAsync: getRoomTokens } = useMutation("get", "/api/auth/room/{id}", undefined);
 
   const targetRoom = useMemo(
+    // TODO: Modify CallPresence to return the room id in order to handle name conflicts
     () => props.rooms.find((r) => r.name === userPresence?.roomName),
     [props.rooms, userPresence?.roomName],
   );

--- a/tauri/src/components/ui/participants.tsx
+++ b/tauri/src/components/ui/participants.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import Fuse from "fuse.js";
 import { Input } from "./input";
 import { HiMagnifyingGlass } from "react-icons/hi2";
+import { useAPI } from "@/services/query";
 
 interface ParticipantsProps {
   teammates: components["schemas"]["BaseUser"][];
@@ -23,6 +24,11 @@ export const Participants = ({ teammates }: ParticipantsProps) => {
   const [searchQuery, setSearchQuery] = useState("");
 
   const [filteredTeammates, setFilteredTeammates] = useState(teammates);
+
+  const { useQuery } = useAPI();
+  const { data: rooms } = useQuery("get", "/api/auth/rooms", undefined, {
+    staleTime: 10_000,
+  });
 
   useEffect(() => {
     if (searchQuery === "") {
@@ -53,7 +59,7 @@ export const Participants = ({ teammates }: ParticipantsProps) => {
         <h3 className="muted text-xs text-slate-500 font-medium mb-2">Online ({onlineTeammates.length})</h3>
         <div className="flex flex-col gap-2">
           {onlineTeammates.map((teammate) => (
-            <ParticipantRow key={teammate.id} user={teammate} />
+            <ParticipantRow key={teammate.id} user={teammate} rooms={rooms || []} />
           ))}
         </div>
       </div>
@@ -63,7 +69,7 @@ export const Participants = ({ teammates }: ParticipantsProps) => {
         <ScrollArea className="max-h-full overflow-y-auto mb-4">
           <div className="flex flex-col gap-2">
             {offlineTeammates.map((teammate) => (
-              <ParticipantRow key={teammate.id} user={teammate} />
+              <ParticipantRow key={teammate.id} user={teammate} rooms={rooms || []} />
             ))}
           </div>
         </ScrollArea>


### PR DESCRIPTION
Modifies the call button to say join and allow a user to join a room another participant is in without going to the room view.

This doesn't handle if two rooms have the same name.


https://github.com/user-attachments/assets/76473544-7413-4b75-900f-2a74f9c5ebc3




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enabled joining an existing room directly from a participant entry when room information is available.
  * Added room data loading in the participant list and wired it into each participant row.

* **Bug Fixes**
  * Refined “Call/End” button disabling logic to better match actual call state.
  * Improved join failure handling, including clearer behavior when a trial has expired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #338 