### PR TITLE
Add remote control default setting

### DIFF
--- a/core/src/capture/capturer.rs
+++ b/core/src/capture/capturer.rs
@@ -157,7 +157,6 @@ impl Capturer {
     /// # Parameters
     /// - `content`: The content source to capture (display or window with display_id)
     /// - `stream_resolution`: The resolution of the stream buffer
-    /// - `include_cursor`: Whether to include the cursor in the capture
     ///
     /// # Returns
     /// - `Ok(())`: Successfully started the capture stream
@@ -177,11 +176,12 @@ impl Capturer {
         &mut self,
         content: Content,
         stream_resolution: Extent,
-        include_cursor: bool,
         buffer_source: NativeVideoSource,
         scale: f64,
     ) -> Result<(), CapturerError> {
-        log::info!("start_capture: content {content:?} resolution: {stream_resolution:?} include_cursor: {include_cursor} scale: {scale}");
+        log::info!(
+            "start_capture: content {content:?} resolution: {stream_resolution:?} scale: {scale}"
+        );
         if self.active_stream.is_some() {
             log::warn!("start_capture: active stream, stopping it");
             self.active_stream.as_mut().unwrap().stop_capture();
@@ -192,39 +192,12 @@ impl Capturer {
             stream_resolution,
             scale,
             self.tx.clone(),
-            include_cursor,
             buffer_source,
         )?;
 
         stream.start_capture(content.id)?;
         self.active_stream = Some(stream);
         Ok(())
-    }
-
-    /// Updates whether the active stream includes the system cursor.
-    /// Restarts the stream only when the policy changes.
-    pub fn set_include_cursor(&mut self, include_cursor: bool) {
-        let Some(mut stream) = self.active_stream.take() else {
-            return;
-        };
-        if !stream.set_include_cursor(include_cursor) {
-            self.active_stream = Some(stream);
-            return;
-        }
-
-        log::info!("set_include_cursor: applying cursor policy change");
-        let Ok(mut stream) = stream.copy() else {
-            log::error!("set_include_cursor: failed to copy capture stream");
-            let _ = self.event_loop_proxy.send_event(UserEvent::StopScreenShare);
-            return;
-        };
-        let source_id = stream.source_id();
-        if let Err(error) = stream.start_capture(source_id) {
-            log::error!("set_include_cursor: failed to restart capture stream: {error:?}");
-            let _ = self.event_loop_proxy.send_event(UserEvent::StopScreenShare);
-            return;
-        }
-        self.active_stream = Some(stream);
     }
 
     /// Signals the capture thread to stop and releases the active stream.

--- a/core/src/capture/capturer.rs
+++ b/core/src/capture/capturer.rs
@@ -201,6 +201,19 @@ impl Capturer {
         Ok(())
     }
 
+    /// Updates whether the active stream includes the system cursor.
+    /// Restarts the stream only when the policy changes.
+    pub fn set_include_cursor(&mut self, include_cursor: bool) {
+        let Some(stream) = self.active_stream.as_mut() else {
+            return;
+        };
+        if !stream.set_include_cursor(include_cursor) {
+            return;
+        }
+
+        self.restart_stream();
+    }
+
     /// Signals the capture thread to stop and releases the active stream.
     /// The thread is detached and will exit on its own.
     /// Safe to call when no stream is active (no-op).

--- a/core/src/capture/capturer.rs
+++ b/core/src/capture/capturer.rs
@@ -188,12 +188,7 @@ impl Capturer {
             self.active_stream = None;
         }
 
-        let mut stream = Stream::new(
-            stream_resolution,
-            scale,
-            self.tx.clone(),
-            buffer_source,
-        )?;
+        let mut stream = Stream::new(stream_resolution, scale, self.tx.clone(), buffer_source)?;
 
         stream.start_capture(content.id)?;
         self.active_stream = Some(stream);

--- a/core/src/capture/capturer.rs
+++ b/core/src/capture/capturer.rs
@@ -204,14 +204,27 @@ impl Capturer {
     /// Updates whether the active stream includes the system cursor.
     /// Restarts the stream only when the policy changes.
     pub fn set_include_cursor(&mut self, include_cursor: bool) {
-        let Some(stream) = self.active_stream.as_mut() else {
+        let Some(mut stream) = self.active_stream.take() else {
             return;
         };
         if !stream.set_include_cursor(include_cursor) {
+            self.active_stream = Some(stream);
             return;
         }
 
-        self.restart_stream();
+        log::info!("set_include_cursor: applying cursor policy change");
+        let Ok(mut stream) = stream.copy() else {
+            log::error!("set_include_cursor: failed to copy capture stream");
+            let _ = self.event_loop_proxy.send_event(UserEvent::StopScreenShare);
+            return;
+        };
+        let source_id = stream.source_id();
+        if let Err(error) = stream.start_capture(source_id) {
+            log::error!("set_include_cursor: failed to restart capture stream: {error:?}");
+            let _ = self.event_loop_proxy.send_event(UserEvent::StopScreenShare);
+            return;
+        }
+        self.active_stream = Some(stream);
     }
 
     /// Signals the capture thread to stop and releases the active stream.

--- a/core/src/capture/macos_stream.rs
+++ b/core/src/capture/macos_stream.rs
@@ -44,7 +44,6 @@ pub struct Stream {
     stream_resolution: Extent,
     source_id: u32,
     failures_count: Arc<Mutex<u64>>,
-    include_cursor: bool,
     output_extent: Arc<Mutex<Extent>>,
     scale: f64,
 }
@@ -54,7 +53,6 @@ impl Stream {
         stream_resolution: Extent,
         scale: f64,
         tx: mpsc::Sender<StreamRuntimeMessage>,
-        include_cursor: bool,
         buffer_source: NativeVideoSource,
     ) -> Result<Self, CapturerError> {
         Ok(Stream {
@@ -66,7 +64,6 @@ impl Stream {
             stream_resolution,
             source_id: 0,
             failures_count: Arc::new(Mutex::new(0)),
-            include_cursor,
             output_extent: Arc::new(Mutex::new(Extent {
                 width: 0.,
                 height: 0.,
@@ -120,7 +117,7 @@ impl Stream {
             .with_width(stream_width)
             .with_height(stream_height)
             .with_pixel_format(PixelFormat::YCbCr_420v)
-            .with_shows_cursor(self.include_cursor)
+            .with_shows_cursor(false)
             .with_fps(60);
 
         let filter = SCContentFilter::create()
@@ -273,7 +270,6 @@ impl Stream {
             stream_resolution: self.stream_resolution,
             source_id: self.source_id,
             failures_count: self.failures_count.clone(),
-            include_cursor: self.include_cursor,
             output_extent: self.output_extent.clone(),
             scale: self.scale,
         })
@@ -285,14 +281,6 @@ impl Stream {
 
     pub fn source_id(&self) -> u32 {
         self.source_id
-    }
-
-    pub fn set_include_cursor(&mut self, include_cursor: bool) -> bool {
-        if self.include_cursor == include_cursor {
-            return false;
-        }
-        self.include_cursor = include_cursor;
-        true
     }
 
     pub fn get_stream_extent(&self) -> Extent {

--- a/core/src/capture/macos_stream.rs
+++ b/core/src/capture/macos_stream.rs
@@ -287,6 +287,14 @@ impl Stream {
         self.source_id
     }
 
+    pub fn set_include_cursor(&mut self, include_cursor: bool) -> bool {
+        if self.include_cursor == include_cursor {
+            return false;
+        }
+        self.include_cursor = include_cursor;
+        true
+    }
+
     pub fn get_stream_extent(&self) -> Extent {
         *self.output_extent.lock().unwrap()
     }

--- a/core/src/capture/stream.rs
+++ b/core/src/capture/stream.rs
@@ -513,6 +513,14 @@ impl Stream {
         self.source_id
     }
 
+    pub fn set_include_cursor(&mut self, include_cursor: bool) -> bool {
+        if self.include_cursor == include_cursor {
+            return false;
+        }
+        self.include_cursor = include_cursor;
+        true
+    }
+
     pub fn get_stream_extent(&self) -> Extent {
         let stream_buffer = self.stream_buffer.lock().unwrap();
         Extent {

--- a/core/src/capture/stream.rs
+++ b/core/src/capture/stream.rs
@@ -298,9 +298,6 @@ pub struct Stream {
     /// When this reaches MAX_STREAM_FAILURES_BEFORE_EXIT, the process exits
     /// to trigger application restart.
     failures_count: Arc<Mutex<u64>>,
-
-    /// Whether to include the cursor in the capture
-    include_cursor: bool,
 }
 
 impl Stream {
@@ -310,7 +307,6 @@ impl Stream {
     /// - `stream_resolution`: The resolution of the stream buffer
     /// - `_scale`: Display scale factor (currently unused but reserved for future scaling)
     /// - `tx`: Channel sender for communicating runtime messages back to the main capturer
-    /// - `include_cursor`: Whether to include the cursor in the capture
     ///
     /// # Returns
     /// - `Ok(Stream)`: Successfully created stream ready for capture
@@ -319,7 +315,6 @@ impl Stream {
         stream_resolution: Extent,
         _scale: f64,
         tx: mpsc::Sender<StreamRuntimeMessage>,
-        include_cursor: bool,
         buffer_source: NativeVideoSource,
     ) -> Result<Self, CapturerError> {
         let stream_buffer = Arc::new(Mutex::new(StreamBuffer::new(1, 1)));
@@ -359,7 +354,6 @@ impl Stream {
             stream_resolution,
             source_id: 0,
             failures_count,
-            include_cursor,
         })
     }
 
@@ -478,7 +472,6 @@ impl Stream {
             stream_resolution: self.stream_resolution,
             source_id: self.source_id,
             failures_count: self.failures_count.clone(),
-            include_cursor: self.include_cursor,
         };
 
         Ok(new_stream)
@@ -511,14 +504,6 @@ impl Stream {
     /// they reconnect to the same source.
     pub fn source_id(&self) -> u32 {
         self.source_id
-    }
-
-    pub fn set_include_cursor(&mut self, include_cursor: bool) -> bool {
-        if self.include_cursor == include_cursor {
-            return false;
-        }
-        self.include_cursor = include_cursor;
-        true
     }
 
     pub fn get_stream_extent(&self) -> Extent {

--- a/core/src/input/mouse.rs
+++ b/core/src/input/mouse.rs
@@ -739,11 +739,7 @@ impl CursorController {
 
             controller.set_position(global_position, local_position);
             if controller.has_control() {
-                let mut cursor_simulator = self
-                    .remote_control
-                    .cursor_simulator
-                    .lock()
-                    .unwrap();
+                let mut cursor_simulator = self.remote_control.cursor_simulator.lock().unwrap();
                 cursor_simulator.simulate_cursor_movement(global_position, controller.clicked());
             }
             break;
@@ -791,11 +787,7 @@ impl CursorController {
                 controller.set_clicked(click_data.down);
             }
 
-            let mut cursor_simulator = self
-                .remote_control
-                .cursor_simulator
-                .lock()
-                .unwrap();
+            let mut cursor_simulator = self.remote_control.cursor_simulator.lock().unwrap();
             /* Take the cursor to the controller's position. */
             cursor_simulator.simulate_cursor_movement(global_position, false);
             cursor_simulator.simulate_click(click_data);
@@ -817,11 +809,7 @@ impl CursorController {
         drop(controllers_cursors);
 
         /* Show the sharer cursor. */
-        let mut sharer_cursor = self
-            .remote_control
-            .sharer_cursor
-            .lock()
-            .unwrap();
+        let mut sharer_cursor = self.remote_control.sharer_cursor.lock().unwrap();
         if sharer_cursor.has_control() && control_changed {
             sharer_cursor.show();
         }
@@ -867,11 +855,7 @@ impl CursorController {
                 controller.hide();
             }
 
-            let mut cursor_simulator = self
-                .remote_control
-                .cursor_simulator
-                .lock()
-                .unwrap();
+            let mut cursor_simulator = self.remote_control.cursor_simulator.lock().unwrap();
             cursor_simulator.simulate_cursor_movement(controller.global_position(), false);
             cursor_simulator.simulate_scroll(delta);
 
@@ -892,11 +876,7 @@ impl CursorController {
         drop(controllers_cursors);
 
         /* Show the sharer cursor. */
-        let mut sharer_cursor = self
-            .remote_control
-            .sharer_cursor
-            .lock()
-            .unwrap();
+        let mut sharer_cursor = self.remote_control.sharer_cursor.lock().unwrap();
         if sharer_cursor.has_control() && control_changed {
             sharer_cursor.show();
         }
@@ -944,11 +924,7 @@ impl CursorController {
         };
 
         if any_had_control {
-            let mut sharer_cursor = self
-                .remote_control
-                .sharer_cursor
-                .lock()
-                .unwrap();
+            let mut sharer_cursor = self.remote_control.sharer_cursor.lock().unwrap();
             sharer_cursor.hide(false);
         }
     }
@@ -982,11 +958,7 @@ impl CursorController {
         };
 
         if had_control {
-            let mut sharer_cursor = self
-                .remote_control
-                .sharer_cursor
-                .lock()
-                .unwrap();
+            let mut sharer_cursor = self.remote_control.sharer_cursor.lock().unwrap();
             sharer_cursor.hide(false);
         }
     }

--- a/core/src/input/mouse.rs
+++ b/core/src/input/mouse.rs
@@ -557,9 +557,8 @@ struct RemoteControl {
 /// Constructor returns `CursorControllerError` with specific failure reasons:
 /// - `MouseObserverCreationFailed`: Platform mouse capture initialization failed
 pub struct CursorController {
-    /// Objects that are used for remote control. When accessibility permission is not granted,
-    /// this is None.
-    remote_control: Option<RemoteControl>,
+    /// Objects used for remote control and the sharer's virtual cursor.
+    remote_control: RemoteControl,
     /// Cursors for the remote controllers.
     ///
     /// LOCK ORDER: this mutex MUST NOT be held when locking
@@ -596,7 +595,6 @@ impl CursorController {
     /// * `overlay_window` - Shared overlay window for coordinate transformations
     /// * `redraw_thread_sender` - Sender for triggering redraws
     /// * `event_loop_proxy` - Event loop proxy for sending cursor position updates
-    /// * `accessibility_permission` - Whether accessibility permissions are granted
     /// * `clock` - Clock for time tracking
     ///
     /// # Returns
@@ -607,40 +605,31 @@ impl CursorController {
         overlay_window: Arc<OverlayWindow>,
         redraw_thread_sender: Sender<RedrawThreadCommands>,
         event_loop_proxy: EventLoopProxy<UserEvent>,
-        accessibility_permission: bool,
         clock: Arc<dyn Clock>,
     ) -> Result<Self, CursorControllerError> {
         let controllers_cursors = Arc::new(Mutex::new(vec![]));
-        let remote_control = if accessibility_permission {
-            let cursor_simulator = Arc::new(Mutex::new(CursorSimulator::new()));
-            let sharer_cursor = Arc::new(Mutex::new(SharerCursor::new(
-                CursorState::new(redraw_thread_sender.clone(), clock.clone()),
-                event_loop_proxy.clone(),
-                overlay_window.clone(),
-                cursor_simulator.clone(),
-                controllers_cursors.clone(),
-            )));
-
-            let mouse_observer = MouseObserver::new(sharer_cursor.clone());
-            if mouse_observer.is_err() {
-                error!("CursorController::new: error creating mouse observer");
-                return Err(CursorControllerError::MouseObserverCreationFailed);
-            }
-            let mouse_observer = mouse_observer.unwrap();
-
-            Some(RemoteControl {
-                sharer_cursor,
-                cursor_simulator,
-                _mouse_observer: mouse_observer,
-            })
-        } else {
-            None
+        let cursor_simulator = Arc::new(Mutex::new(CursorSimulator::new()));
+        let sharer_cursor = Arc::new(Mutex::new(SharerCursor::new(
+            CursorState::new(redraw_thread_sender.clone(), clock.clone()),
+            event_loop_proxy.clone(),
+            overlay_window.clone(),
+            cursor_simulator.clone(),
+            controllers_cursors.clone(),
+        )));
+        let mouse_observer = MouseObserver::new(sharer_cursor.clone()).map_err(|_| {
+            log::error!("CursorController::new: error creating mouse observer");
+            CursorControllerError::MouseObserverCreationFailed
+        })?;
+        let remote_control = RemoteControl {
+            sharer_cursor,
+            cursor_simulator,
+            _mouse_observer: mouse_observer,
         };
 
         Ok(Self {
             remote_control,
             controllers_cursors,
-            controllers_cursors_enabled: accessibility_permission,
+            controllers_cursors_enabled: true,
             overlay_window,
             redraw_thread_sender,
             event_loop_proxy,
@@ -749,11 +738,9 @@ impl CursorController {
             let global_position = self.overlay_window.translate_to_global(x, y);
 
             controller.set_position(global_position, local_position);
-            if controller.has_control() && self.remote_control.is_some() {
+            if controller.has_control() {
                 let mut cursor_simulator = self
                     .remote_control
-                    .as_ref()
-                    .unwrap()
                     .cursor_simulator
                     .lock()
                     .unwrap();
@@ -775,11 +762,6 @@ impl CursorController {
     /// * `identity` - Session ID identifying which controller is clicking
     pub fn mouse_click_controller(&mut self, mut click_data: MouseClickData, identity: &str) {
         debug!("mouse_click_controller: {click_data:?}");
-        if self.remote_control.is_none() {
-            log::warn!("mouse_click_controller: remote control is none");
-            return;
-        }
-
         let mut control_changed = false;
         let mut controllers_cursors = self.controllers_cursors.lock().unwrap();
         for controller in controllers_cursors.iter_mut() {
@@ -811,8 +793,6 @@ impl CursorController {
 
             let mut cursor_simulator = self
                 .remote_control
-                .as_ref()
-                .unwrap()
                 .cursor_simulator
                 .lock()
                 .unwrap();
@@ -839,8 +819,6 @@ impl CursorController {
         /* Show the sharer cursor. */
         let mut sharer_cursor = self
             .remote_control
-            .as_ref()
-            .unwrap()
             .sharer_cursor
             .lock()
             .unwrap();
@@ -872,11 +850,6 @@ impl CursorController {
     pub fn scroll_controller(&mut self, delta: ScrollDelta, identity: &str) {
         debug!("scroll_controller: {delta:?}");
 
-        if self.remote_control.is_none() {
-            log::warn!("scroll_controller: remote control is none");
-            return;
-        }
-
         let mut control_changed = false;
         let mut controllers_cursors = self.controllers_cursors.lock().unwrap();
         for controller in controllers_cursors.iter_mut() {
@@ -896,8 +869,6 @@ impl CursorController {
 
             let mut cursor_simulator = self
                 .remote_control
-                .as_ref()
-                .unwrap()
                 .cursor_simulator
                 .lock()
                 .unwrap();
@@ -923,8 +894,6 @@ impl CursorController {
         /* Show the sharer cursor. */
         let mut sharer_cursor = self
             .remote_control
-            .as_ref()
-            .unwrap()
             .sharer_cursor
             .lock()
             .unwrap();
@@ -954,11 +923,6 @@ impl CursorController {
     /// * `enabled` - Whether to enable (true) or disable (false) input for all controllers
     pub fn set_controllers_enabled(&mut self, enabled: bool) {
         log::info!("set_controllers_enabled: {enabled}");
-        if self.remote_control.is_none() {
-            log::warn!("set_controllers_enabled: remote control is none");
-            return;
-        }
-
         let any_had_control = {
             let mut controllers_cursors = self.controllers_cursors.lock().unwrap();
             self.controllers_cursors_enabled = enabled;
@@ -982,8 +946,6 @@ impl CursorController {
         if any_had_control {
             let mut sharer_cursor = self
                 .remote_control
-                .as_ref()
-                .unwrap()
                 .sharer_cursor
                 .lock()
                 .unwrap();
@@ -1022,8 +984,6 @@ impl CursorController {
         if had_control {
             let mut sharer_cursor = self
                 .remote_control
-                .as_ref()
-                .unwrap()
                 .sharer_cursor
                 .lock()
                 .unwrap();
@@ -1045,14 +1005,11 @@ impl CursorController {
         participants_manager: &mut crate::graphics::graphics_context::participant::ParticipantsManager,
     ) {
         // Update sharer cursor
-        if let Some(remote_control) = &self.remote_control {
-            let sharer_cursor = remote_control.sharer_cursor.lock().unwrap();
-            if sharer_cursor.visible() {
-                participants_manager
-                    .set_cursor_position("local", Some(sharer_cursor.local_position()));
-            } else {
-                participants_manager.set_cursor_position("local", None);
-            }
+        let sharer_cursor = self.remote_control.sharer_cursor.lock().unwrap();
+        if sharer_cursor.visible() {
+            participants_manager.set_cursor_position("local", Some(sharer_cursor.local_position()));
+        } else {
+            participants_manager.set_cursor_position("local", None);
         }
 
         // Update controller cursors
@@ -1072,20 +1029,6 @@ impl CursorController {
         self.overlay_window.clone()
     }
 
-    /// Triggers a click animation at the specified position for a given controller.
-    ///
-    /// This method handles the visual click animation feedback when a controller
-    /// with pointer mode enabled performs a click action. It sends the necessary
-    /// events to update the graphics and trigger the animation sequence.
-    ///
-    /// # Parameters
-    ///
-    /// * `position` - The position where the click animation should be displayed
-    /// * `identity` - Session ID of the controller triggering the animation
-    pub fn is_controllers_enabled(&self) -> bool {
-        self.controllers_cursors_enabled
-    }
-
     /// Hides cursors that have been inactive for longer than `CURSOR_HIDE_TIMEOUT`.
     ///
     /// This should be called during each redraw cycle, similar to how
@@ -1100,9 +1043,7 @@ impl CursorController {
             }
         }
 
-        if let Some(remote_control) = &self.remote_control {
-            let mut sharer_cursor = remote_control.sharer_cursor.lock().unwrap();
-            sharer_cursor.cursor_state.hide_if_expired();
-        }
+        let mut sharer_cursor = self.remote_control.sharer_cursor.lock().unwrap();
+        sharer_cursor.cursor_state.hide_if_expired();
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -220,7 +220,6 @@ pub struct Application<'a> {
     socket_responses: std::sync::mpsc::Receiver<socket_lib::Message>,
     room_service: Option<RoomService>,
     event_loop_proxy: EventLoopProxy<UserEvent>,
-    previous_controllers_enabled: bool,
     controller_draw_persist: bool,
     last_mode: Option<socket_lib::StoredMode>,
     window_manager: Option<window_manager::WindowManager<'a>>,
@@ -309,7 +308,6 @@ impl<'a> Application<'a> {
             socket_responses,
             room_service: None,
             event_loop_proxy,
-            previous_controllers_enabled: false,
             controller_draw_persist: false,
             last_mode: None,
             window_manager: None,
@@ -840,18 +838,25 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
             UserEvent::ControllerCursorEnabled(enabled) => {
                 log::debug!("user_event: cursor enabled: {enabled:?}");
                 self.remote_control_enabled = enabled;
+
+                self.screen_capturer
+                    .lock()
+                    .unwrap()
+                    .set_include_cursor(!enabled);
+
                 let Some(remote_control) = self.remote_control.as_mut() else {
                     log::debug!(
                         "user_event: saved remote control preference for the next screen share"
                     );
                     return;
                 };
-                let Some(room_service) = self.room_service.as_ref() else {
-                    log::warn!("user_event: room service is none cursor enabled");
-                    return;
-                };
-                remote_control.set_enabled(enabled);
-                room_service.publish_controller_cursor_enabled(enabled);
+                if self.drawing_window.as_ref().is_none_or(|w| !w.is_visible()) {
+                    remote_control.set_enabled(enabled);
+                }
+
+                if let Some(room_service) = self.room_service.as_ref() {
+                    room_service.publish_controller_cursor_enabled(enabled);
+                }
             }
             UserEvent::Keystroke(keystroke_data) => {
                 log::debug!("user_event: keystroke: {keystroke_data:?}");
@@ -1893,11 +1898,6 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                 if self.drawing_window.as_ref().is_none_or(|w| !w.is_visible()) {
                     let remote_control = self.remote_control.as_mut().unwrap();
 
-                    // Store the current controller state before disabling
-                    let previous_controllers_enabled =
-                        remote_control.cursor_controller.is_controllers_enabled();
-                    self.previous_controllers_enabled = previous_controllers_enabled;
-
                     // Disable remote control
                     remote_control.set_enabled(false);
 
@@ -1943,9 +1943,9 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                             Err(e) => {
                                 log::error!("Failed to create drawing window: {e:?}");
 
-                                // Restore remote control to previous state
+                                // Restore the saved remote control preference
                                 let remote_control = self.remote_control.as_mut().unwrap();
-                                remote_control.set_enabled(previous_controllers_enabled);
+                                remote_control.set_enabled(self.remote_control_enabled);
 
                                 if let Some(room_service) = &self.room_service {
                                     room_service
@@ -1962,8 +1962,8 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                         room_service.publish_draw_clear_all_paths();
                     }
 
-                    // Restore remote control to previous state
-                    remote_control.set_enabled(self.previous_controllers_enabled);
+                    // Restore the saved remote control preference
+                    remote_control.set_enabled(self.remote_control_enabled);
 
                     if let Some(room_service) = &self.room_service {
                         room_service.publish_drawing_mode(room_service::DrawingMode::Disabled);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -106,8 +106,6 @@ const SOCKET_MESSAGE_TIMEOUT_SECONDS: u64 = 30;
 const STREAM_FAILURE_EXIT_CODE: i32 = 2;
 const HANG_PROTECTION_EXIT_CODE: i32 = 3;
 const HANG_PROTECTION_INTERVAL_SECONDS: u64 = 30;
-const REMOTE_CONTROL_ENABLED: bool = true;
-
 #[derive(Error, Debug)]
 pub enum ServerError {
     #[error("Livekit room service not found")]
@@ -144,6 +142,11 @@ struct RemoteControl {
 }
 
 impl RemoteControl {
+    fn set_enabled(&mut self, enabled: bool) {
+        self.cursor_controller.set_controllers_enabled(enabled);
+        self.keyboard_controller.set_enabled(enabled);
+    }
+
     /// Renders a complete frame by updating cursors, hiding inactive ones, clearing expired paths, and drawing.
     ///
     /// # Returns
@@ -234,6 +237,7 @@ pub struct Application<'a> {
     hang_protection_counter: Arc<AtomicU64>,
     start_camera_on_call: bool,
     screen_share_resolution: ScreenShareResolution,
+    remote_control_enabled: bool,
     clipboard_controller: Option<ClipboardController>,
     screen_selection_active: bool,
 }
@@ -322,6 +326,7 @@ impl<'a> Application<'a> {
             hang_protection_counter,
             start_camera_on_call: false,
             screen_share_resolution: ScreenShareResolution::P4K,
+            remote_control_enabled: true,
             clipboard_controller,
             screen_selection_active: false,
         })
@@ -413,7 +418,7 @@ impl<'a> Application<'a> {
                 width: screenshare_input.resolution.width,
                 height: screenshare_input.resolution.height,
             },
-            !REMOTE_CONTROL_ENABLED,
+            !self.remote_control_enabled,
             buffer_source,
             scale,
         );
@@ -434,7 +439,7 @@ impl<'a> Application<'a> {
 
         drop(screen_capturer);
 
-        let res = self.create_overlay_window(monitor, REMOTE_CONTROL_ENABLED);
+        let res = self.create_overlay_window(monitor, self.remote_control_enabled);
         if let Err(e) = res {
             self.stop_screenshare();
             log::error!("screenshare: error creating overlay window: {e:?}");
@@ -719,22 +724,25 @@ impl<'a> Application<'a> {
         let redraw_sender = gfx.redraw_sender();
         let clock = gfx.clock();
 
+        // Keep the input infrastructure available so remote control can be
+        // enabled later without recreating the overlay.
         let cursor_controller = CursorController::new(
             overlay_window,
             redraw_sender,
             self.event_loop_proxy.clone(),
-            remote_control_enabled,
+            true,
             clock,
-        );
-        if let Err(error) = cursor_controller {
+        )
+        .map_err(|error| {
             log::error!("create_overlay_window: Error creating cursor controller {error:?}");
-            return Err(ServerError::CursorControllerCreationError);
-        }
-
-        self.remote_control = Some(RemoteControl {
-            cursor_controller: cursor_controller.unwrap(),
+            ServerError::CursorControllerCreationError
+        })?;
+        let mut remote_control = RemoteControl {
+            cursor_controller,
             keyboard_controller: KeyboardController::<KeyboardLayout>::new(),
-        });
+        };
+        remote_control.set_enabled(remote_control_enabled);
+        self.remote_control = Some(remote_control);
 
         Ok(())
     }
@@ -831,23 +839,19 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
             }
             UserEvent::ControllerCursorEnabled(enabled) => {
                 log::debug!("user_event: cursor enabled: {enabled:?}");
-                if self.remote_control.is_none() {
-                    log::warn!("user_event: remote control is none cursor enabled ");
+                self.remote_control_enabled = enabled;
+                let Some(remote_control) = self.remote_control.as_mut() else {
+                    log::debug!(
+                        "user_event: saved remote control preference for the next screen share"
+                    );
                     return;
-                }
-                if self.room_service.is_none() {
+                };
+                let Some(room_service) = self.room_service.as_ref() else {
                     log::warn!("user_event: room service is none cursor enabled");
                     return;
-                }
-                let remote_control = &mut self.remote_control.as_mut().unwrap();
-                let cursor_controller = &mut remote_control.cursor_controller;
-                cursor_controller.set_controllers_enabled(enabled);
-                let keyboard_controller = &mut remote_control.keyboard_controller;
-                keyboard_controller.set_enabled(enabled);
-                self.room_service
-                    .as_ref()
-                    .unwrap()
-                    .publish_controller_cursor_enabled(enabled);
+                };
+                remote_control.set_enabled(enabled);
+                room_service.publish_controller_cursor_enabled(enabled);
             }
             UserEvent::Keystroke(keystroke_data) => {
                 log::debug!("user_event: keystroke: {keystroke_data:?}");
@@ -1895,10 +1899,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     self.previous_controllers_enabled = previous_controllers_enabled;
 
                     // Disable remote control
-                    remote_control
-                        .cursor_controller
-                        .set_controllers_enabled(false);
-                    remote_control.keyboard_controller.set_enabled(false);
+                    remote_control.set_enabled(false);
 
                     let draw_mode = room_service::DrawingMode::Draw(room_service::DrawSettings {
                         permanent: drawing_enabled.permanent,
@@ -1944,12 +1945,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
 
                                 // Restore remote control to previous state
                                 let remote_control = self.remote_control.as_mut().unwrap();
-                                remote_control
-                                    .cursor_controller
-                                    .set_controllers_enabled(previous_controllers_enabled);
-                                remote_control
-                                    .keyboard_controller
-                                    .set_enabled(previous_controllers_enabled);
+                                remote_control.set_enabled(previous_controllers_enabled);
 
                                 if let Some(room_service) = &self.room_service {
                                     room_service
@@ -1967,12 +1963,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     }
 
                     // Restore remote control to previous state
-                    remote_control
-                        .cursor_controller
-                        .set_controllers_enabled(self.previous_controllers_enabled);
-                    remote_control
-                        .keyboard_controller
-                        .set_enabled(self.previous_controllers_enabled);
+                    remote_control.set_enabled(self.previous_controllers_enabled);
 
                     if let Some(room_service) = &self.room_service {
                         room_service.publish_drawing_mode(room_service::DrawingMode::Disabled);

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -844,14 +844,14 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     .unwrap()
                     .set_include_cursor(!enabled);
 
-                let Some(remote_control) = self.remote_control.as_mut() else {
+                if let Some(remote_control) = self.remote_control.as_mut() {
+                    if self.drawing_window.as_ref().is_none_or(|w| !w.is_visible()) {
+                        remote_control.set_enabled(enabled);
+                    }
+                } else {
                     log::debug!(
                         "user_event: saved remote control preference for the next screen share"
                     );
-                    return;
-                };
-                if self.drawing_window.as_ref().is_none_or(|w| !w.is_visible()) {
-                    remote_control.set_enabled(enabled);
                 }
 
                 if let Some(room_service) = self.room_service.as_ref() {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -416,7 +416,6 @@ impl<'a> Application<'a> {
                 width: screenshare_input.resolution.width,
                 height: screenshare_input.resolution.height,
             },
-            !self.remote_control_enabled,
             buffer_source,
             scale,
         );
@@ -722,13 +721,10 @@ impl<'a> Application<'a> {
         let redraw_sender = gfx.redraw_sender();
         let clock = gfx.clock();
 
-        // Keep the input infrastructure available so remote control can be
-        // enabled later without recreating the overlay.
         let cursor_controller = CursorController::new(
             overlay_window,
             redraw_sender,
             self.event_loop_proxy.clone(),
-            true,
             clock,
         )
         .map_err(|error| {
@@ -838,11 +834,6 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
             UserEvent::ControllerCursorEnabled(enabled) => {
                 log::debug!("user_event: cursor enabled: {enabled:?}");
                 self.remote_control_enabled = enabled;
-
-                self.screen_capturer
-                    .lock()
-                    .unwrap()
-                    .set_include_cursor(!enabled);
 
                 if let Some(remote_control) = self.remote_control.as_mut() {
                     if self.drawing_window.as_ref().is_none_or(|w| !w.is_visible()) {

--- a/tauri/src-tauri/src/app_state.rs
+++ b/tauri/src-tauri/src/app_state.rs
@@ -17,6 +17,8 @@ pub struct UserSettings {
     pub show_dock_icon_in_call: bool,
     pub start_camera_on_call: bool,
     pub start_mic_on_call: bool,
+    #[serde(default = "default_true")]
+    pub remote_control_enabled: bool,
     #[serde(default = "default_noise_cancellation_enabled")]
     pub noise_cancellation_enabled: bool,
     #[serde(default = "default_screen_share_resolution")]
@@ -39,6 +41,7 @@ impl Default for UserSettings {
             show_dock_icon_in_call: true,
             start_camera_on_call: false,
             start_mic_on_call: true,
+            remote_control_enabled: true,
             noise_cancellation_enabled: true,
             screen_share_resolution: ScreenShareResolution::P4K,
             hopp_server_url: None,

--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -60,6 +60,14 @@ async fn get_available_content(app: tauri::AppHandle) -> Result<(), String> {
     let data = app.state::<Mutex<AppData>>();
     let data = data.lock().unwrap();
 
+    let remote_control_enabled = data.app_state.user_settings().remote_control_enabled;
+    data.sender
+        .send(Message::ControllerCursorEnabled(remote_control_enabled))
+        .map_err(|e| {
+            log::error!("get_available_content: failed to apply remote control setting: {e:?}");
+            "Failed to apply remote control setting".to_string()
+        })?;
+
     data.sender.send(Message::GetAvailableContent).map_err(|e| {
         log::error!("get_available_content: failed to send message: {e:?}");
         "Failed to start screen selection".to_string()
@@ -812,6 +820,17 @@ fn set_start_mic_on_call(app: tauri::AppHandle, enabled: bool) {
     let mut data = data.lock().unwrap();
     data.app_state
         .update_user_setting(|s| s.start_mic_on_call = enabled);
+}
+
+#[tauri::command(async)]
+fn set_remote_control_enabled(app: tauri::AppHandle, enabled: bool) {
+    log::info!("set_remote_control_enabled: {enabled}");
+    let data = app.state::<Mutex<AppData>>();
+    let mut data = data.lock().unwrap();
+    data.app_state
+        .update_user_setting(|s| s.remote_control_enabled = enabled);
+    drop(data);
+    set_controller_cursor(app, enabled);
 }
 
 #[tauri::command(async)]
@@ -1641,6 +1660,7 @@ fn main() {
             set_auto_update_enabled,
             set_start_camera_on_call,
             set_start_mic_on_call,
+            set_remote_control_enabled,
             set_shortcut_toggle_mic,
             set_shortcut_toggle_camera,
             set_shortcut_toggle_screenshare,

--- a/tauri/src/components/ui/call-center.tsx
+++ b/tauri/src/components/ui/call-center.tsx
@@ -62,20 +62,20 @@ export function CallCenter() {
     toast.success("Room link copied to clipboard");
   };
 
-  const fetchAccessibilityPermission = async () => {
-    const permission = await tauriUtils.getControlPermission();
-    setAccessibilityPermission(permission);
-    const enabled = permission && (userSettings?.remote_control_enabled ?? false);
-    setControllerCursorState(enabled);
-
-    if (callTokens?.role === ParticipantRole.SHARER && userSettings) {
-      tauriUtils.setControllerCursor(enabled);
-    }
-  };
-
   useEffect(() => {
+    const fetchAccessibilityPermission = async () => {
+      const permission = await tauriUtils.getControlPermission();
+      setAccessibilityPermission(permission);
+      const enabled = permission && (userSettings?.remote_control_enabled ?? true);
+      setControllerCursorState(enabled);
+
+      if (callTokens?.role === ParticipantRole.SHARER && userSettings) {
+        tauriUtils.setControllerCursor(enabled);
+      }
+    };
+
     fetchAccessibilityPermission();
-  }, [callTokens?.role, userSettings?.remote_control_enabled]);
+  }, [callTokens?.role, userSettings]);
 
   useEffect(() => {
     const unlisten = listen("core_call_ended", () => {

--- a/tauri/src/components/ui/call-center.tsx
+++ b/tauri/src/components/ui/call-center.tsx
@@ -65,18 +65,17 @@ export function CallCenter() {
   const fetchAccessibilityPermission = async () => {
     const permission = await tauriUtils.getControlPermission();
     setAccessibilityPermission(permission);
-    setControllerCursorState(permission);
+    const enabled = permission && (userSettings?.remote_control_enabled ?? false);
+    setControllerCursorState(enabled);
 
-    if (callTokens?.role === ParticipantRole.SHARER && (!permission || (permission && !accessibilityPermission))) {
-      setTimeout(() => {
-        tauriUtils.setControllerCursor(permission);
-      }, 2000);
+    if (callTokens?.role === ParticipantRole.SHARER && userSettings) {
+      tauriUtils.setControllerCursor(enabled);
     }
   };
 
   useEffect(() => {
     fetchAccessibilityPermission();
-  }, [callTokens?.role]);
+  }, [callTokens?.role, userSettings?.remote_control_enabled]);
 
   useEffect(() => {
     const unlisten = listen("core_call_ended", () => {

--- a/tauri/src/core_payloads.ts
+++ b/tauri/src/core_payloads.ts
@@ -91,6 +91,7 @@ export interface UserSettings {
   show_dock_icon_in_call: boolean;
   start_camera_on_call: boolean;
   start_mic_on_call: boolean;
+  remote_control_enabled: boolean;
   noise_cancellation_enabled: boolean;
   screen_share_resolution: ScreenShareResolution;
   hopp_server_url: string | null;
@@ -195,6 +196,7 @@ export interface CommandMap {
   set_auto_update_enabled: { args: { enabled: boolean }; return: void };
   set_start_camera_on_call: { args: { enabled: boolean }; return: void };
   set_start_mic_on_call: { args: { enabled: boolean }; return: void };
+  set_remote_control_enabled: { args: { enabled: boolean }; return: void };
   set_shortcut_toggle_mic: { args: { accel: string }; return: void };
   set_shortcut_toggle_camera: { args: { accel: string }; return: void };
   set_shortcut_toggle_screenshare: { args: { accel: string }; return: void };

--- a/tauri/src/windows/settings/main.tsx
+++ b/tauri/src/windows/settings/main.tsx
@@ -296,6 +296,14 @@ function SettingsWindow() {
           <div className="grid grid-cols-[minmax(100px,140px)_1fr] gap-8">
             <h3 className="text-base font-medium text-black dark:text-white">Screen share settings</h3>
             <div className="flex flex-col gap-3">
+              <CheckboxRow
+                title="Enable remote control by default"
+                description="Allow teammates to control your computer when screen sharing starts"
+                checked={settings.remote_control_enabled}
+                onCheckedChange={(v) => {
+                  typedInvoke("set_remote_control_enabled", { enabled: v }).then(() => refetchSettings());
+                }}
+              />
               <ResolutionRow
                 value={settings.screen_share_resolution}
                 onValueChange={(resolution) => {


### PR DESCRIPTION
## What changed

- Added a persisted setting to enable or disable remote control by default.
- Applied the saved preference before every screen share starts.
- Kept temporary in-call overrides scoped to the active share.
- Centralized mouse and keyboard enablement in the existing remote-control abstraction.

## Why

Screen sharing previously always initialized remote control as enabled, so users could only disable it after sharing had started.

## Impact

Users can now start screen sharing with remote input disabled while retaining the existing in-call toggle.

## Validation

- `git diff --check`
- Build and type checks were not run because workspace dependencies are not installed and project instructions prohibit agent-run interactive builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persisted setting to enable or disable remote control during screen sharing.
  * Added a “Screen share settings” checkbox to toggle remote control (updates the running session immediately).

* **Bug Fixes**
  * Remote-control activation is now consistent across accessibility permission, screen-sharing state, and local drawing mode.
  * Cursor/keyboard simulation updates reliably when sharing starts/stops and when local drawing begins/ends.
  * Screen capture no longer includes cursor visuals via a configurable option; captured video hides the cursor consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->