### PR TITLE
feat: add window sharing

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -1,7 +1,10 @@
 use std::env;
+use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=HOPP_CORE_BIN_DEFAULT");
+    println!("cargo:rerun-if-env-changed=DEVELOPER_DIR");
     let is_default = env::var("HOPP_CORE_BIN_DEFAULT").unwrap_or("0".to_string()) == "1";
     let binary_name = if is_default {
         "hopp_core"
@@ -35,4 +38,57 @@ fn main() {
         println!("cargo:rustc-link-arg-bin=hopp_core=-o");
         println!("cargo:rustc-link-arg-bin=hopp_core={output_dir}/{binary_name}");
     }
+
+    // Swift bridges (apple-metal / screencapturekit) auto-link
+    // libswiftCompatibility*.a. Those live under the active Xcode
+    // toolchain; stale CLT paths from dependency build scripts are not
+    // enough, so resolve and emit the search path here.
+    if target.contains("apple-darwin") {
+        link_swift_compatibility_libs();
+    }
+}
+
+fn link_swift_compatibility_libs() {
+    let developer_dir = env::var("DEVELOPER_DIR")
+        .ok()
+        .filter(|path| !path.is_empty())
+        .or_else(|| {
+            Command::new("xcode-select")
+                .arg("-p")
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        });
+
+    let Some(developer_dir) = developer_dir else {
+        println!(
+            "cargo:warning=could not resolve DEVELOPER_DIR / xcode-select -p; \
+             Swift compatibility libraries may fail to link"
+        );
+        return;
+    };
+
+    let candidates = [
+        PathBuf::from(&developer_dir)
+            .join("Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"),
+        // Full Xcode when xcode-select still points at Command Line Tools.
+        PathBuf::from("/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx"),
+        PathBuf::from("/Library/Developer/CommandLineTools/usr/lib/swift/macosx"),
+    ];
+
+    let Some(swift_lib_dir) = candidates.into_iter().find(|path| {
+        path.join("libswiftCompatibility56.a").is_file()
+            && path.join("libswiftCompatibilityConcurrency.a").is_file()
+    }) else {
+        println!(
+            "cargo:warning=Swift compatibility libraries not found under {developer_dir}; \
+             install full Xcode or set DEVELOPER_DIR"
+        );
+        return;
+    };
+
+    // Search path only — Swift object files already carry auto-link
+    // directives for the compatibility libraries.
+    println!("cargo:rustc-link-search=native={}", swift_lib_dir.display());
 }

--- a/core/socket_lib/src/lib.rs
+++ b/core/socket_lib/src/lib.rs
@@ -86,29 +86,46 @@ pub struct KeystrokeMessage {
     pub down: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContentType {
     Display,
+    Window,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct Content {
     pub content_type: ContentType,
-    pub id: u32,
+    pub id: u64,
 }
 
 impl fmt::Display for Content {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.content_type {
             ContentType::Display => write!(f, "Display {}", self.id),
+            ContentType::Window => write!(f, "Window {}", self.id),
         }
     }
+}
+
+/// Frame of a shared window relative to its containing monitor (physical pixels).
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Default)]
+pub struct WindowFrame {
+    pub origin_x: f64,
+    pub origin_y: f64,
+    pub width: f64,
+    pub height: f64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ScreenShareMessage {
     pub content: Content,
     pub resolution: Extent,
+    /// Capture id of the monitor hosting the share. Equals `content.id` for displays.
+    #[serde(default)]
+    pub monitor_id: Option<u64>,
+    /// Present when sharing a window; omitted/None for full-display shares.
+    #[serde(default)]
+    pub window_frame: Option<WindowFrame>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/core/src/capture/capturer.rs
+++ b/core/src/capture/capturer.rs
@@ -3,7 +3,10 @@ use livekit::webrtc::video_source::native::NativeVideoSource;
 use socket_lib::Content;
 use winit::{dpi::PhysicalPosition, event_loop::EventLoopProxy, monitor::MonitorHandle};
 
-use crate::{utils::geometry::Extent, UserEvent, STREAM_FAILURE_EXIT_CODE};
+use crate::{
+    utils::geometry::{Extent, Frame},
+    UserEvent, STREAM_FAILURE_EXIT_CODE,
+};
 
 /// Platform-agnostic monitor identifier.
 ///
@@ -61,6 +64,10 @@ pub enum CapturerError {
     /// Couldn't find selected source.
     #[error("Couldn't find selected source")]
     SelectedSourceNotFound,
+
+    /// Capture source type is not supported on this platform.
+    #[error("Unsupported capture content type")]
+    UnsupportedContentType,
 }
 
 /// Platform-specific extensions for screen sharing and monitor management.
@@ -79,7 +86,7 @@ pub trait ScreenshareExt {
     /// # Returns
     /// The `MonitorHandle` for the specified monitor. If the monitor ID is not found,
     /// returns the first available monitor as a fallback.
-    fn get_selected_monitor(monitors: &[MonitorHandle], input_id: u32) -> MonitorHandle;
+    fn get_selected_monitor(monitors: &[MonitorHandle], input_id: u64) -> MonitorHandle;
 
     /// Returns a platform-agnostic identifier for the given monitor.
     ///
@@ -92,7 +99,7 @@ pub trait ScreenshareExt {
 
     /// Reverse mapping: returns the capture content id (used by `Content.id`)
     /// for the given monitor, or `None` if it cannot be resolved.
-    fn capture_content_id_for_monitor(monitor: &MonitorHandle) -> Option<u32>;
+    fn capture_content_id_for_monitor(monitor: &MonitorHandle) -> Option<u64>;
 }
 
 /// Main interface for managing screen capture operations and stream lifecycle.
@@ -178,6 +185,7 @@ impl Capturer {
         stream_resolution: Extent,
         buffer_source: NativeVideoSource,
         scale: f64,
+        display_position: winit::dpi::PhysicalPosition<i32>,
     ) -> Result<(), CapturerError> {
         log::info!(
             "start_capture: content {content:?} resolution: {stream_resolution:?} scale: {scale}"
@@ -188,9 +196,17 @@ impl Capturer {
             self.active_stream = None;
         }
 
-        let mut stream = Stream::new(stream_resolution, scale, self.tx.clone(), buffer_source)?;
+        let mut stream = Stream::new(
+            stream_resolution,
+            scale,
+            display_position,
+            self.tx.clone(),
+            buffer_source,
+            content.content_type,
+            self.event_loop_proxy.clone(),
+        )?;
 
-        stream.start_capture(content.id)?;
+        stream.start_capture(content)?;
         self.active_stream = Some(stream);
         Ok(())
     }
@@ -261,7 +277,8 @@ impl Capturer {
                 // So we just sleep and retry a few times in case it's a temporary error.
                 // If we can't restart the stream after 10 retries, we exit the process
                 // and inform the user to restart the application.
-                let mut res = new_stream.start_capture(new_stream.source_id());
+                let restart_content = new_stream.capture_content();
+                let mut res = new_stream.start_capture(restart_content);
                 for i in 0..MAX_STREAM_FAILURES_BEFORE_EXIT {
                     if res.is_ok() {
                         break;
@@ -285,7 +302,7 @@ impl Capturer {
                             std::process::exit(STREAM_FAILURE_EXIT_CODE);
                         }
                     };
-                    res = new_stream.start_capture(new_stream.source_id());
+                    res = new_stream.start_capture(new_stream.capture_content());
                 }
 
                 if let Err(ref e) = res {
@@ -336,7 +353,7 @@ impl Capturer {
         }
     }
 
-    pub fn get_selected_monitor(&self, monitors: &[MonitorHandle], input_id: u32) -> MonitorHandle {
+    pub fn get_selected_monitor(&self, monitors: &[MonitorHandle], input_id: u64) -> MonitorHandle {
         #[cfg(any(target_os = "windows", target_os = "macos"))]
         {
             ScreenshareFunctions::get_selected_monitor(monitors, input_id)
@@ -391,6 +408,18 @@ impl Capturer {
         Extent {
             width: 0.,
             height: 0.,
+        }
+    }
+
+    /// Live capture bounds in physical pixels relative to the shared display.
+    /// Empty/zero when no stream is active or still starting.
+    pub fn get_capture_frame(&self) -> Option<Frame> {
+        let stream = self.active_stream.as_ref()?;
+        let frame = stream.get_capture_frame();
+        if frame.extent.width <= 0.0 || frame.extent.height <= 0.0 {
+            None
+        } else {
+            Some(frame)
         }
     }
 }

--- a/core/src/capture/linux.rs
+++ b/core/src/capture/linux.rs
@@ -5,7 +5,7 @@ pub struct ScreenshareFunctions {}
 impl ScreenshareExt for ScreenshareFunctions {
     fn get_selected_monitor(
         monitors: &[winit::monitor::MonitorHandle],
-        _input_id: u32,
+        _input_id: u64,
     ) -> winit::monitor::MonitorHandle {
         monitors[0].clone()
     }
@@ -14,7 +14,7 @@ impl ScreenshareExt for ScreenshareFunctions {
         MonitorId::Position(monitor.position())
     }
 
-    fn capture_content_id_for_monitor(_monitor: &winit::monitor::MonitorHandle) -> Option<u32> {
+    fn capture_content_id_for_monitor(_monitor: &winit::monitor::MonitorHandle) -> Option<u64> {
         Some(0)
     }
 }

--- a/core/src/capture/macos.rs
+++ b/core/src/capture/macos.rs
@@ -8,11 +8,11 @@ pub struct ScreenshareFunctions {}
 impl ScreenshareExt for ScreenshareFunctions {
     fn get_selected_monitor(
         monitors: &[winit::monitor::MonitorHandle],
-        input_id: u32,
+        input_id: u64,
     ) -> winit::monitor::MonitorHandle {
         let mut selected_monitor = monitors[0].clone();
         for monitor in monitors {
-            if monitor.native_id() == input_id {
+            if monitor.native_id() as u64 == input_id {
                 selected_monitor = monitor.clone();
             }
         }
@@ -23,8 +23,8 @@ impl ScreenshareExt for ScreenshareFunctions {
         MonitorId::Numeric(monitor.native_id())
     }
 
-    fn capture_content_id_for_monitor(monitor: &winit::monitor::MonitorHandle) -> Option<u32> {
-        Some(monitor.native_id())
+    fn capture_content_id_for_monitor(monitor: &winit::monitor::MonitorHandle) -> Option<u64> {
+        Some(monitor.native_id() as u64)
     }
 }
 

--- a/core/src/capture/macos_stream.rs
+++ b/core/src/capture/macos_stream.rs
@@ -1,4 +1,5 @@
 use crate::utils::geometry::{aspect_fit, Extent, Frame};
+use crate::UserEvent;
 use livekit::webrtc::{
     prelude::{NV12Buffer, VideoFrame, VideoRotation},
     video_source::native::NativeVideoSource,
@@ -8,9 +9,13 @@ use screencapturekit::{
     prelude::*,
     stream::delegate_trait::StreamCallbacks,
 };
+use socket_lib::{Content, ContentType};
 use std::sync::{mpsc, Arc, Mutex};
+use winit::dpi::PhysicalPosition;
+use winit::event_loop::EventLoopProxy;
 
 use super::CapturerError;
+use crate::capture::window_bounds_macos;
 
 #[allow(dead_code)]
 pub enum StreamRuntimeMessage {
@@ -43,18 +48,23 @@ pub struct Stream {
     buffer_source: NativeVideoSource,
     frame: Arc<Mutex<Frame>>,
     stream_resolution: Extent,
-    source_id: u32,
+    content: Content,
     failures_count: Arc<Mutex<u64>>,
     output_extent: Arc<Mutex<Extent>>,
     scale: f64,
+    display_position: PhysicalPosition<i32>,
+    event_loop_proxy: EventLoopProxy<UserEvent>,
 }
 
 impl Stream {
     pub fn new(
         stream_resolution: Extent,
         scale: f64,
+        display_position: PhysicalPosition<i32>,
         tx: mpsc::Sender<StreamRuntimeMessage>,
         buffer_source: NativeVideoSource,
+        content_type: ContentType,
+        event_loop_proxy: EventLoopProxy<UserEvent>,
     ) -> Result<Self, CapturerError> {
         Ok(Stream {
             sc_stream: None,
@@ -63,36 +73,69 @@ impl Stream {
             buffer_source,
             frame: Arc::new(Mutex::new(Frame::default())),
             stream_resolution,
-            source_id: 0,
+            content: Content {
+                content_type,
+                id: 0,
+            },
             failures_count: Arc::new(Mutex::new(0)),
             output_extent: Arc::new(Mutex::new(Extent {
                 width: 0.,
                 height: 0.,
             })),
             scale,
+            display_position,
+            event_loop_proxy,
         })
     }
 
-    pub fn start_capture(&mut self, id: u32) -> Result<(), CapturerError> {
-        log::info!("macos_stream::start_capture: Starting capture for id: {id}");
+    pub fn start_capture(&mut self, content: Content) -> Result<(), CapturerError> {
+        log::info!("macos_stream::start_capture: Starting capture for {content}");
 
-        let content = SCShareableContent::get().map_err(|e| {
+        let shareable = SCShareableContent::get().map_err(|e| {
             log::error!("start_capture: Failed to get shareable content: {e}");
             CapturerError::DesktopCapturerCreationError
         })?;
 
-        let displays = content.displays();
-        if displays.is_empty() {
-            return Err(CapturerError::CaptureSourceListEmpty);
-        }
+        let (native_width, native_height, filter) = match content.content_type {
+            ContentType::Display => {
+                let displays = shareable.displays();
+                if displays.is_empty() {
+                    return Err(CapturerError::CaptureSourceListEmpty);
+                }
+                let display = displays
+                    .into_iter()
+                    .find(|d| d.display_id() as u64 == content.id)
+                    .ok_or(CapturerError::SelectedSourceNotFound)?;
+                let native_width = (display.width() as f64 * self.scale) as u32;
+                let native_height = (display.height() as f64 * self.scale) as u32;
+                let filter = SCContentFilter::create()
+                    .with_display(&display)
+                    .with_excluding_windows(&[])
+                    .build();
+                (native_width, native_height, filter)
+            }
+            ContentType::Window => {
+                let window = shareable
+                    .windows()
+                    .into_iter()
+                    .find(|w| w.window_id() as u64 == content.id)
+                    .ok_or(CapturerError::SelectedSourceNotFound)?;
+                let frame = window.frame();
+                let native_width = (frame.size.width * self.scale).round().max(1.0) as u32;
+                let native_height = (frame.size.height * self.scale).round().max(1.0) as u32;
+                // Seed overlay bounds from CGWindowList (top-left Quartz space).
+                if let Some(seed) = window_bounds_macos::display_local_frame_on_monitor(
+                    window.window_id(),
+                    self.scale,
+                    self.display_position,
+                ) {
+                    *self.frame.lock().unwrap() = seed;
+                }
+                let filter = SCContentFilter::create().with_window(&window).build();
+                (native_width, native_height, filter)
+            }
+        };
 
-        let display = displays
-            .into_iter()
-            .find(|d| d.display_id() == id)
-            .ok_or(CapturerError::SelectedSourceNotFound)?;
-
-        let native_width = (display.width() as f64 * self.scale) as u32;
-        let native_height = (display.height() as f64 * self.scale) as u32;
         let (stream_width, stream_height) = aspect_fit(
             native_width,
             native_height,
@@ -100,7 +143,7 @@ impl Stream {
             self.stream_resolution.height as u32,
         );
         log::info!(
-            "start_capture: output {stream_width}x{stream_height} from display {native_width}x{native_height} (scale: {})",
+            "start_capture: output {stream_width}x{stream_height} from source {native_width}x{native_height} (scale: {})",
             self.scale
         );
 
@@ -120,11 +163,6 @@ impl Stream {
             .with_pixel_format(PixelFormat::YCbCr_420v)
             .with_shows_cursor(false)
             .with_fps(60);
-
-        let filter = SCContentFilter::create()
-            .with_display(&display)
-            .with_excluding_windows(&[])
-            .build();
 
         let error_tx = self.permanent_error_tx.clone();
         let stop_tx = self.permanent_error_tx.clone();
@@ -146,6 +184,15 @@ impl Stream {
         let buffer_source = self.buffer_source.clone();
         let failures_count = self.failures_count.clone();
         let frame_arc = self.frame.clone();
+        let scale = self.scale;
+        let event_loop_proxy = self.event_loop_proxy.clone();
+        let track_window_id = matches!(content.content_type, ContentType::Window).then_some(content.id);
+        let last_window_query = Mutex::new(
+            std::time::Instant::now()
+                .checked_sub(std::time::Duration::from_secs(1))
+                .unwrap_or_else(std::time::Instant::now),
+        );
+        let display_position = self.display_position;
         let capture_start = std::time::Instant::now();
 
         let handler = move |sample: CMSampleBuffer, of_type: SCStreamOutputType| {
@@ -196,14 +243,51 @@ impl Stream {
                 return;
             }
 
-            // Update frame metadata
-            {
-                if let Some(content_rect) = sample.content_rect() {
+            // Keep overlay markers glued to the shared window as it moves/resizes.
+            // Window shares: CGWindowList bounds (top-left Quartz → display-local physical).
+            // Display shares: SCK content_rect (top-left display points).
+            let next_frame = if let Some(window_id) = track_window_id {
+                let should_query = {
+                    let mut last = last_window_query.lock().unwrap();
+                    if last.elapsed() >= std::time::Duration::from_millis(50) {
+                        *last = std::time::Instant::now();
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if should_query {
+                    window_bounds_macos::display_local_frame_on_monitor(
+                        window_id as u32,
+                        scale,
+                        display_position,
+                    )
+                } else {
+                    None
+                }
+            } else {
+                sample.content_rect().map(|content_rect| Frame {
+                    origin_x: content_rect.origin.x * scale,
+                    origin_y: content_rect.origin.y * scale,
+                    extent: Extent {
+                        width: content_rect.size.width * scale,
+                        height: content_rect.size.height * scale,
+                    },
+                })
+            };
+
+            if let Some(next) = next_frame {
+                let changed = {
                     let mut frame = frame_arc.lock().unwrap();
-                    frame.origin_x = content_rect.origin.x;
-                    frame.origin_y = content_rect.origin.y;
-                    frame.extent.width = content_rect.size.width;
-                    frame.extent.height = content_rect.size.height;
+                    if *frame != next {
+                        *frame = next;
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if changed {
+                    let _ = event_loop_proxy.send_event(UserEvent::RequestRedraw);
                 }
             }
 
@@ -243,7 +327,7 @@ impl Stream {
         })?;
 
         self.sc_stream = Some(sc_stream);
-        self.source_id = id;
+        self.content = content;
         Ok(())
     }
 
@@ -269,10 +353,12 @@ impl Stream {
             buffer_source: self.buffer_source.clone(),
             frame: self.frame.clone(),
             stream_resolution: self.stream_resolution,
-            source_id: self.source_id,
+            content: self.content,
             failures_count: self.failures_count.clone(),
             output_extent: self.output_extent.clone(),
             scale: self.scale,
+            display_position: self.display_position,
+            event_loop_proxy: self.event_loop_proxy.clone(),
         })
     }
 
@@ -280,11 +366,16 @@ impl Stream {
         *self.failures_count.lock().unwrap()
     }
 
-    pub fn source_id(&self) -> u32 {
-        self.source_id
+    pub fn capture_content(&self) -> Content {
+        self.content
     }
 
     pub fn get_stream_extent(&self) -> Extent {
         *self.output_extent.lock().unwrap()
+    }
+
+    /// Live capture bounds in physical pixels (updated as the shared window moves).
+    pub fn get_capture_frame(&self) -> Frame {
+        *self.frame.lock().unwrap()
     }
 }

--- a/core/src/capture/sources.rs
+++ b/core/src/capture/sources.rs
@@ -1,0 +1,73 @@
+use winit::monitor::MonitorHandle;
+
+use crate::capture::thumbnail::Thumbnail;
+use crate::utils::geometry::Frame;
+
+/// A display or window the user can share.
+#[derive(Debug, Clone)]
+pub struct ShareableSource {
+    pub content: socket_lib::Content,
+    pub title: String,
+    pub app_name: Option<String>,
+    /// Frame relative to the containing monitor in physical pixels.
+    /// Zero extent for full-display shares.
+    pub frame: Frame,
+    /// Capture content id of the monitor used for overlay / remote control.
+    pub monitor_content_id: u64,
+    /// Optional picker preview image.
+    pub thumbnail: Option<Thumbnail>,
+}
+
+impl ShareableSource {
+    pub fn display_label(&self) -> String {
+        if let Some(app) = &self.app_name {
+            if !app.is_empty() && app != &self.title {
+                return format!("{app} — {}", self.title);
+            }
+        }
+        self.title.clone()
+    }
+}
+
+/// Result of enumerating shareable application windows.
+#[derive(Debug, Clone, Default)]
+pub struct ListedWindows {
+    pub windows: Vec<ShareableSource>,
+    pub error: Option<String>,
+}
+
+/// Lists shareable displays for the current platform.
+pub fn list_displays(monitors: &[MonitorHandle]) -> Vec<ShareableSource> {
+    platform::list_displays(monitors)
+}
+
+/// Lists shareable application windows. Empty on Linux (unsupported in v1).
+pub fn list_windows(monitors: &[MonitorHandle]) -> ListedWindows {
+    platform::list_windows(monitors)
+}
+
+pub fn windows_supported() -> bool {
+    platform::windows_supported()
+}
+
+fn display_title(index: usize, monitor: &MonitorHandle) -> String {
+    monitor
+        .name()
+        .map(|name| {
+            if name.is_empty() {
+                format!("Screen {}", index + 1)
+            } else {
+                name
+            }
+        })
+        .unwrap_or_else(|| format!("Screen {}", index + 1))
+}
+
+fn full_display_frame() -> Frame {
+    Frame::default()
+}
+
+#[cfg_attr(target_os = "macos", path = "sources_macos.rs")]
+#[cfg_attr(target_os = "windows", path = "sources_windows.rs")]
+#[cfg_attr(target_os = "linux", path = "sources_linux.rs")]
+mod platform;

--- a/core/src/capture/sources_linux.rs
+++ b/core/src/capture/sources_linux.rs
@@ -1,0 +1,37 @@
+use socket_lib::{Content, ContentType};
+use winit::monitor::MonitorHandle;
+
+use super::{display_title, full_display_frame, ListedWindows, ShareableSource};
+use crate::capture::capturer::{ScreenshareExt, ScreenshareFunctions};
+
+pub fn windows_supported() -> bool {
+    false
+}
+
+pub fn list_displays(monitors: &[MonitorHandle]) -> Vec<ShareableSource> {
+    monitors
+        .iter()
+        .enumerate()
+        .filter_map(|(index, monitor)| {
+            let id = ScreenshareFunctions::capture_content_id_for_monitor(monitor)?;
+            Some(ShareableSource {
+                content: Content {
+                    content_type: ContentType::Display,
+                    id,
+                },
+                title: display_title(index, monitor),
+                app_name: None,
+                frame: full_display_frame(),
+                monitor_content_id: id,
+                thumbnail: None,
+            })
+        })
+        .collect()
+}
+
+pub fn list_windows(_monitors: &[MonitorHandle]) -> ListedWindows {
+    ListedWindows {
+        windows: Vec::new(),
+        error: Some("Window sharing is not available on Linux yet.".to_string()),
+    }
+}

--- a/core/src/capture/sources_macos.rs
+++ b/core/src/capture/sources_macos.rs
@@ -1,0 +1,177 @@
+use screencapturekit::prelude::*;
+use socket_lib::{Content, ContentType};
+use winit::monitor::MonitorHandle;
+
+use super::{display_title, full_display_frame, ListedWindows, ShareableSource};
+use crate::capture::capturer::{ScreenshareExt, ScreenshareFunctions};
+use crate::capture::thumbnail::{self, Thumbnail};
+use crate::capture::window_bounds_macos;
+use crate::utils::geometry::{Extent, Frame};
+
+pub fn windows_supported() -> bool {
+    true
+}
+
+pub fn list_displays(monitors: &[MonitorHandle]) -> Vec<ShareableSource> {
+    monitors
+        .iter()
+        .enumerate()
+        .filter_map(|(index, monitor)| {
+            let id = ScreenshareFunctions::capture_content_id_for_monitor(monitor)?;
+            let thumbnail = thumbnail::display_thumbnail(id as u32);
+            Some(ShareableSource {
+                content: Content {
+                    content_type: ContentType::Display,
+                    id,
+                },
+                title: display_title(index, monitor),
+                app_name: None,
+                frame: full_display_frame(),
+                monitor_content_id: id,
+                thumbnail,
+            })
+        })
+        .collect()
+}
+
+pub fn list_windows(monitors: &[MonitorHandle]) -> ListedWindows {
+    let content = match SCShareableContent::get() {
+        Ok(content) => content,
+        Err(error) => {
+            log::error!("list_windows: SCShareableContent::get failed: {error}");
+            let message = error.to_string();
+            let hint = if message.contains("declined")
+                || message.contains("TCC")
+                || message.contains("Content unavailable")
+            {
+                "Screen Recording permission is required to share windows. Enable Hopp in System Settings → Privacy & Security → Screen Recording, then restart the app.".to_string()
+            } else {
+                format!("Could not list windows: {error}")
+            };
+            return ListedWindows {
+                windows: Vec::new(),
+                error: Some(hint),
+            };
+        }
+    };
+
+    let displays = content.displays();
+    let windows: Vec<ShareableSource> = content
+        .windows()
+        .into_iter()
+        .filter_map(|window| {
+            if !window.is_on_screen() || window.window_layer() != 0 {
+                return None;
+            }
+            let title = window.title()?.trim().to_string();
+            if title.is_empty() {
+                return None;
+            }
+
+            let app_name = window
+                .owning_application()
+                .map(|app| app.application_name())
+                .filter(|name| !name.is_empty());
+
+            if is_hopp_window(&title, app_name.as_deref()) {
+                return None;
+            }
+
+            let window_id = window.window_id();
+            let cg_frame = window.frame();
+            if cg_frame.size.width <= 1.0 || cg_frame.size.height <= 1.0 {
+                return None;
+            }
+
+            // Prefer Quartz bounds for overlay alignment; fall back to SCWindow.frame so a
+            // failed CG lookup never empties the picker.
+            let (monitor_content_id, frame) = window_bounds_macos::display_local_frame_for_window(
+                window_id, monitors,
+            )
+            .or_else(|| resolve_sc_window_monitor(&cg_frame, &displays, monitors))?;
+
+            let thumb: Option<Thumbnail> = thumbnail::window_thumbnail(window_id);
+
+            Some(ShareableSource {
+                content: Content {
+                    content_type: ContentType::Window,
+                    id: window_id as u64,
+                },
+                title,
+                app_name,
+                frame,
+                monitor_content_id,
+                thumbnail: thumb,
+            })
+        })
+        .collect();
+
+    if windows.is_empty() {
+        log::warn!(
+            "list_windows: no shareable windows after filtering (SC windows may lack titles or bounds)"
+        );
+    } else {
+        log::info!("list_windows: listed {} windows", windows.len());
+    }
+
+    ListedWindows {
+        windows,
+        error: None,
+    }
+}
+
+fn is_hopp_window(title: &str, app_name: Option<&str>) -> bool {
+    let title_lower = title.to_ascii_lowercase();
+    if title_lower.contains("hopp") {
+        return true;
+    }
+    app_name
+        .map(|name| name.to_ascii_lowercase().contains("hopp"))
+        .unwrap_or(false)
+}
+
+/// Resolve monitor + display-local frame from SCWindow/SCDisplay coordinates.
+/// SC shareable frames share one coordinate space; we map into winit physical pixels.
+fn resolve_sc_window_monitor(
+    cg_frame: &screencapturekit::cg::CGRect,
+    displays: &[SCDisplay],
+    monitors: &[MonitorHandle],
+) -> Option<(u64, Frame)> {
+    let center_x = cg_frame.origin.x + cg_frame.size.width / 2.0;
+    let center_y = cg_frame.origin.y + cg_frame.size.height / 2.0;
+
+    let display = displays.iter().find(|display| {
+        let frame = display.frame();
+        center_x >= frame.origin.x
+            && center_x < frame.origin.x + frame.size.width
+            && center_y >= frame.origin.y
+            && center_y < frame.origin.y + frame.size.height
+    })?;
+
+    let display_id = display.display_id() as u64;
+    let display_frame = display.frame();
+
+    let scale = monitors
+        .iter()
+        .find(|monitor| {
+            ScreenshareFunctions::capture_content_id_for_monitor(monitor)
+                .map(|id| id == display_id)
+                .unwrap_or(false)
+        })
+        .map(|monitor| monitor.scale_factor())
+        .or_else(|| monitors.first().map(|m| m.scale_factor()))
+        .unwrap_or(1.0);
+
+    // SCWindow.frame / SCDisplay.frame use the same space; treat as top-left relative to the
+    // display (matches Quartz / CGWindowList used for live marker updates).
+    let frame = Frame {
+        origin_x: (cg_frame.origin.x - display_frame.origin.x) * scale,
+        origin_y: (cg_frame.origin.y - display_frame.origin.y) * scale,
+        extent: Extent {
+            width: cg_frame.size.width * scale,
+            height: cg_frame.size.height * scale,
+        },
+    };
+
+    Some((display_id, frame))
+}

--- a/core/src/capture/sources_windows.rs
+++ b/core/src/capture/sources_windows.rs
@@ -1,0 +1,103 @@
+use livekit::webrtc::desktop_capturer::{
+    DesktopCaptureSourceType, DesktopCapturer, DesktopCapturerOptions,
+};
+use socket_lib::{Content, ContentType};
+use winit::monitor::MonitorHandle;
+
+use super::{display_title, full_display_frame, ListedWindows, ShareableSource};
+use crate::capture::capturer::{ScreenshareExt, ScreenshareFunctions};
+use crate::utils::geometry::{Extent, Frame};
+
+pub fn windows_supported() -> bool {
+    true
+}
+
+pub fn list_displays(monitors: &[MonitorHandle]) -> Vec<ShareableSource> {
+    monitors
+        .iter()
+        .enumerate()
+        .filter_map(|(index, monitor)| {
+            let id = ScreenshareFunctions::capture_content_id_for_monitor(monitor)?;
+            Some(ShareableSource {
+                content: Content {
+                    content_type: ContentType::Display,
+                    id,
+                },
+                title: display_title(index, monitor),
+                app_name: None,
+                frame: full_display_frame(),
+                monitor_content_id: id,
+                thumbnail: None,
+            })
+        })
+        .collect()
+}
+
+pub fn list_windows(monitors: &[MonitorHandle]) -> ListedWindows {
+    let options = DesktopCapturerOptions::new(DesktopCaptureSourceType::Window);
+    let Some(capturer) = DesktopCapturer::new(options) else {
+        log::error!("list_windows: failed to create DesktopCapturer");
+        return ListedWindows {
+            windows: Vec::new(),
+            error: Some("Could not enumerate windows for sharing.".to_string()),
+        };
+    };
+
+    let windows = capturer
+        .get_source_list()
+        .into_iter()
+        .filter_map(|source| {
+            let title = source.title().trim().to_string();
+            if title.is_empty() {
+                return None;
+            }
+            if title.to_ascii_lowercase().contains("hopp") {
+                return None;
+            }
+
+            let monitor_content_id = resolve_monitor_id(source.display_id(), monitors);
+            Some(ShareableSource {
+                content: Content {
+                    content_type: ContentType::Window,
+                    id: source.id(),
+                },
+                title,
+                app_name: None,
+                // Bounds are refined when capture starts / overlay is created.
+                frame: Frame {
+                    origin_x: 0.,
+                    origin_y: 0.,
+                    extent: Extent {
+                        width: 0.,
+                        height: 0.,
+                    },
+                },
+                monitor_content_id,
+                thumbnail: None,
+            })
+        })
+        .collect();
+
+    ListedWindows {
+        windows,
+        error: None,
+    }
+}
+
+fn resolve_monitor_id(display_id: i64, monitors: &[MonitorHandle]) -> u64 {
+    if display_id >= 0 {
+        let as_u64 = display_id as u64;
+        if monitors.iter().any(|monitor| {
+            ScreenshareFunctions::capture_content_id_for_monitor(monitor)
+                .map(|id| id == as_u64)
+                .unwrap_or(false)
+        }) {
+            return as_u64;
+        }
+    }
+
+    monitors
+        .first()
+        .and_then(ScreenshareFunctions::capture_content_id_for_monitor)
+        .unwrap_or(0)
+}

--- a/core/src/capture/stream.rs
+++ b/core/src/capture/stream.rs
@@ -1,4 +1,5 @@
 use crate::utils::geometry::{aspect_fit, Extent, Frame};
+use crate::UserEvent;
 use livekit::webrtc::{
     desktop_capturer::{
         CaptureError, DesktopCaptureSourceType, DesktopCapturer, DesktopCapturerOptions,
@@ -8,7 +9,9 @@ use livekit::webrtc::{
     prelude::{NV12Buffer, VideoBuffer, VideoFrame, VideoRotation},
     video_source::native::NativeVideoSource,
 };
+use socket_lib::{Content, ContentType};
 use std::sync::{mpsc, Arc, Mutex};
+use winit::event_loop::EventLoopProxy;
 
 use super::CapturerError;
 
@@ -98,6 +101,7 @@ fn create_capture_callback(
     desktop_frame: Arc<Mutex<Frame>>,
     tx: mpsc::Sender<StreamRuntimeMessage>,
     failures_count: Arc<Mutex<u64>>,
+    event_loop_proxy: EventLoopProxy<UserEvent>,
 ) -> impl FnMut(Result<DesktopFrame, CaptureError>) {
     let mut capture_buffer = NV12Buffer::new(1, 1);
     let mut stream_failed = false;
@@ -166,6 +170,7 @@ fn create_capture_callback(
                 frame.extent.height = frame_height as f64;
                 frame.origin_x = frame_left as f64;
                 frame.origin_y = frame_top as f64;
+                let _ = event_loop_proxy.send_event(UserEvent::RequestRedraw);
             }
         }
 
@@ -292,8 +297,8 @@ pub struct Stream {
     /// The resolution of the stream buffer.
     stream_resolution: Extent,
 
-    /// Identifier of the capture source (display or window ID).
-    source_id: u32,
+    /// Identifier of the capture source (display or window).
+    content: Content,
 
     /// Counter tracking consecutive stream failures for health monitoring.
     ///
@@ -301,6 +306,9 @@ pub struct Stream {
     /// When this reaches MAX_STREAM_FAILURES_BEFORE_EXIT, the process exits
     /// to trigger application restart.
     failures_count: Arc<Mutex<u64>>,
+
+    /// Proxy used to request overlay redraws when the shared window moves.
+    event_loop_proxy: EventLoopProxy<UserEvent>,
 }
 
 impl Stream {
@@ -317,9 +325,18 @@ impl Stream {
     pub fn new(
         stream_resolution: Extent,
         _scale: f64,
+        _display_position: winit::dpi::PhysicalPosition<i32>,
         tx: mpsc::Sender<StreamRuntimeMessage>,
         buffer_source: NativeVideoSource,
+        content_type: ContentType,
+        event_loop_proxy: EventLoopProxy<UserEvent>,
     ) -> Result<Self, CapturerError> {
+        #[cfg(target_os = "linux")]
+        if content_type == ContentType::Window {
+            log::error!("Stream::new: window capture is not supported on Linux");
+            return Err(CapturerError::UnsupportedContentType);
+        }
+
         let stream_buffer = Arc::new(Mutex::new(StreamBuffer::new(1, 1)));
         let frame = Arc::new(Mutex::new(Frame {
             origin_x: 0.,
@@ -331,8 +348,13 @@ impl Stream {
         }));
         let failures_count = Arc::new(Mutex::new(0));
 
+        let source_type = match content_type {
+            ContentType::Display => DesktopCaptureSourceType::Screen,
+            ContentType::Window => DesktopCaptureSourceType::Window,
+        };
+
         #[allow(unused_mut)]
-        let mut options = DesktopCapturerOptions::new(DesktopCaptureSourceType::Screen);
+        let mut options = DesktopCapturerOptions::new(source_type);
         #[cfg(target_os = "macos")]
         {
             options.set_sck_system_picker(false);
@@ -355,27 +377,35 @@ impl Stream {
             buffer_source,
             frame,
             stream_resolution,
-            source_id: 0,
+            content: Content {
+                content_type,
+                id: 0,
+            },
             failures_count,
+            event_loop_proxy,
         })
     }
 
     /// Starts capturing frames from the specified source.
     ///
     /// # Parameters
-    /// - `id`: The identifier of the capture source (display or window ID)
+    /// - `content`: The content source to capture (display or window)
     ///
     /// # Behavior
     /// - Finds the capture source matching the provided ID from available sources
-    /// - Falls back to the first available source if the specified ID is not found
     /// - Spawns a background worker thread that continuously captures frames
     /// - Begins the frame capture loop at FRAME_CAPTURE_INTERVAL_MS intervals
     ///
     /// # Notes
     /// This method should only be called when the stream is not already capturing.
     /// The capture thread will run until `stop_capture()` is called.
-    pub fn start_capture(&mut self, id: u32) -> Result<(), CapturerError> {
-        log::info!("stream::start_capture: Starting capture for id: {id}");
+    pub fn start_capture(&mut self, content: Content) -> Result<(), CapturerError> {
+        #[cfg(target_os = "linux")]
+        if content.content_type == ContentType::Window {
+            return Err(CapturerError::UnsupportedContentType);
+        }
+
+        log::info!("stream::start_capture: Starting capture for {content}");
         let callback = create_capture_callback(
             self.buffer_source.clone(),
             self.stream_resolution,
@@ -383,6 +413,7 @@ impl Stream {
             self.frame.clone(),
             self.permanent_error_tx.clone(),
             self.failures_count.clone(),
+            self.event_loop_proxy.clone(),
         );
         let mut capturer = self.capturer.lock().unwrap();
         let sources = capturer.get_source_list();
@@ -391,15 +422,15 @@ impl Stream {
         }
         let mut source = sources[0].clone();
         for s in sources {
-            if s.id() == (id as u64) {
+            if s.id() == content.id {
                 source = s;
                 break;
             }
         }
-        if source.id() != (id as u64) {
+        if source.id() != content.id {
             return Err(CapturerError::SelectedSourceNotFound);
         }
-        self.source_id = id;
+        self.content = content;
         capturer.start_capture(Some(source), callback);
         let (tx, rx) = mpsc::channel();
         let capturer_clone = self.capturer.clone();
@@ -449,8 +480,13 @@ impl Stream {
             self.stop_capture();
         }
 
+        let source_type = match self.content.content_type {
+            ContentType::Display => DesktopCaptureSourceType::Screen,
+            ContentType::Window => DesktopCaptureSourceType::Window,
+        };
+
         #[allow(unused_mut)]
-        let mut options = DesktopCapturerOptions::new(DesktopCaptureSourceType::Screen);
+        let mut options = DesktopCapturerOptions::new(source_type);
         #[cfg(target_os = "macos")]
         {
             options.set_sck_system_picker(false);
@@ -473,8 +509,9 @@ impl Stream {
             buffer_source: self.buffer_source.clone(),
             frame: self.frame.clone(),
             stream_resolution: self.stream_resolution,
-            source_id: self.source_id,
+            content: self.content,
             failures_count: self.failures_count.clone(),
+            event_loop_proxy: self.event_loop_proxy.clone(),
         };
 
         Ok(new_stream)
@@ -495,18 +532,9 @@ impl Stream {
         *self.failures_count.lock().unwrap()
     }
 
-    /// Returns the identifier of the capture source.
-    ///
-    /// # Returns
-    /// The ID of the display or window that this stream is currently configured
-    /// to capture from. This corresponds to the ID passed to `start_capture()`.
-    ///
-    /// # Use Cases
-    /// Used for identifying which source a stream is associated with, particularly
-    /// useful when managing multiple streams or when restarting streams to ensure
-    /// they reconnect to the same source.
-    pub fn source_id(&self) -> u32 {
-        self.source_id
+    /// Returns the content source this stream is configured to capture.
+    pub fn capture_content(&self) -> Content {
+        self.content
     }
 
     pub fn get_stream_extent(&self) -> Extent {
@@ -515,6 +543,11 @@ impl Stream {
             width: stream_buffer.video_frame.buffer.width() as f64,
             height: stream_buffer.video_frame.buffer.height() as f64,
         }
+    }
+
+    /// Live capture bounds in physical pixels (updated as the shared window moves).
+    pub fn get_capture_frame(&self) -> Frame {
+        *self.frame.lock().unwrap()
     }
 
     #[cfg(target_os = "linux")]

--- a/core/src/capture/thumbnail.rs
+++ b/core/src/capture/thumbnail.rs
@@ -1,0 +1,49 @@
+//! Share-picker thumbnails.
+
+#[cfg(target_os = "macos")]
+#[path = "thumbnail_macos.rs"]
+mod platform;
+
+#[cfg(not(target_os = "macos"))]
+mod platform {
+    use super::Thumbnail;
+
+    pub fn window_thumbnail(_window_id: u32) -> Option<Thumbnail> {
+        None
+    }
+
+    pub fn display_thumbnail(_display_id: u32) -> Option<Thumbnail> {
+        None
+    }
+}
+
+use std::sync::Arc;
+
+/// RGBA thumbnail with a reusable iced image handle.
+#[derive(Debug, Clone)]
+pub struct Thumbnail {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Arc<[u8]>,
+    pub handle: iced_core::image::Handle,
+}
+
+impl Thumbnail {
+    pub fn from_rgba(width: u32, height: u32, rgba: Vec<u8>) -> Self {
+        let rgba: Arc<[u8]> = rgba.into();
+        let handle =
+            iced_core::image::Handle::from_rgba(width, height, rgba.as_ref().to_vec());
+        Self {
+            width,
+            height,
+            rgba,
+            handle,
+        }
+    }
+
+    pub fn image_handle(&self) -> iced_core::image::Handle {
+        self.handle.clone()
+    }
+}
+
+pub use platform::{display_thumbnail, window_thumbnail};

--- a/core/src/capture/thumbnail_macos.rs
+++ b/core/src/capture/thumbnail_macos.rs
@@ -1,0 +1,89 @@
+//! Capture small RGBA thumbnails for the share picker (macOS).
+
+use core_graphics::display::{CGDisplay, CGPoint, CGRect, CGSize};
+use core_graphics::image::CGImage;
+use core_graphics::window::{
+    create_image, kCGWindowImageBoundsIgnoreFraming, kCGWindowImageNominalResolution,
+    kCGWindowListOptionIncludingWindow,
+};
+use image::imageops::{resize, FilterType};
+use image::RgbaImage;
+
+use super::Thumbnail;
+
+const MAX_THUMB_WIDTH: u32 = 320;
+const MAX_THUMB_HEIGHT: u32 = 180;
+
+pub fn window_thumbnail(window_id: u32) -> Option<Thumbnail> {
+    // CGRectNull → capture the window's own bounds.
+    let bounds = CGRect::new(&CGPoint::new(0., 0.), &CGSize::new(0., 0.));
+    let image = create_image(
+        bounds,
+        kCGWindowListOptionIncludingWindow,
+        window_id,
+        kCGWindowImageBoundsIgnoreFraming | kCGWindowImageNominalResolution,
+    )?;
+    cgimage_to_thumbnail(&image)
+}
+
+pub fn display_thumbnail(display_id: u32) -> Option<Thumbnail> {
+    let image = CGDisplay::new(display_id).image()?;
+    cgimage_to_thumbnail(&image)
+}
+
+fn cgimage_to_thumbnail(image: &CGImage) -> Option<Thumbnail> {
+    let width = image.width();
+    let height = image.height();
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let stride = image.bytes_per_row();
+    let bpp = image.bits_per_pixel() / 8;
+    if bpp < 4 {
+        return None;
+    }
+
+    let data = image.data();
+    let bytes = data.bytes();
+    if bytes.len() < stride * height {
+        return None;
+    }
+
+    let mut rgba = Vec::with_capacity(width * height * 4);
+    for y in 0..height {
+        let row = &bytes[y * stride..y * stride + width * bpp];
+        for px in row.chunks_exact(bpp) {
+            // CGWindow / CGDisplay images are typically BGRA.
+            let (b, g, r, a) = (px[0], px[1], px[2], px[3]);
+            rgba.extend_from_slice(&[r, g, b, a]);
+        }
+    }
+
+    let src = RgbaImage::from_raw(width as u32, height as u32, rgba)?;
+    let (tw, th) = fit_size(width as u32, height as u32, MAX_THUMB_WIDTH, MAX_THUMB_HEIGHT);
+    let resized = if tw == width as u32 && th == height as u32 {
+        src
+    } else {
+        resize(&src, tw, th, FilterType::Triangle)
+    };
+
+    Some(Thumbnail::from_rgba(
+        resized.width(),
+        resized.height(),
+        resized.into_raw(),
+    ))
+}
+
+fn fit_size(width: u32, height: u32, max_w: u32, max_h: u32) -> (u32, u32) {
+    if width == 0 || height == 0 {
+        return (1, 1);
+    }
+    let scale = (max_w as f32 / width as f32)
+        .min(max_h as f32 / height as f32)
+        .min(1.0);
+    (
+        ((width as f32 * scale).round() as u32).max(1),
+        ((height as f32 * scale).round() as u32).max(1),
+    )
+}

--- a/core/src/capture/window_bounds_macos.rs
+++ b/core/src/capture/window_bounds_macos.rs
@@ -1,0 +1,161 @@
+//! Window bounds from CGWindowList — global top-left points (Quartz space).
+
+use core_foundation::base::TCFType;
+use core_foundation::dictionary::CFDictionaryRef;
+use core_foundation::number::CFNumber;
+use core_graphics::display::CGDisplay;
+use core_graphics::geometry::{CGPoint, CGRect, CGSize};
+use core_graphics::window::{
+    kCGWindowBounds, kCGWindowListOptionIncludingWindow, kCGWindowListOptionOnScreenOnly,
+    kCGWindowNumber,
+};
+use std::ffi::c_void;
+use winit::dpi::PhysicalPosition;
+use winit::monitor::MonitorHandle;
+
+use crate::capture::capturer::{ScreenshareExt, ScreenshareFunctions};
+use crate::utils::geometry::{Extent, Frame};
+
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    fn CFDictionaryGetValue(theDict: CFDictionaryRef, key: *const c_void) -> *const c_void;
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGRectMakeWithDictionaryRepresentation(
+        dict: CFDictionaryRef,
+        rect: *mut CGRect,
+    ) -> bool;
+}
+
+/// Global top-left window bounds in points.
+pub fn window_bounds_points(window_id: u32) -> Option<CGRect> {
+    if let Some(rect) =
+        bounds_from_window_list(kCGWindowListOptionIncludingWindow, Some(window_id), window_id)
+    {
+        return Some(rect);
+    }
+
+    bounds_from_window_list(kCGWindowListOptionOnScreenOnly, None, window_id)
+}
+
+fn bounds_from_window_list(
+    option: u32,
+    relative_to: Option<u32>,
+    window_id: u32,
+) -> Option<CGRect> {
+    let infos = CGDisplay::window_list_info(option, relative_to)?;
+    if infos.is_empty() {
+        return None;
+    }
+
+    for dict_ptr in infos.get_all_values() {
+        if dict_ptr.is_null() {
+            continue;
+        }
+        unsafe {
+            if relative_to.is_none() {
+                let number_ptr = CFDictionaryGetValue(
+                    dict_ptr as CFDictionaryRef,
+                    kCGWindowNumber as *const c_void,
+                );
+                if number_ptr.is_null() {
+                    continue;
+                }
+                let number = CFNumber::wrap_under_get_rule(number_ptr as _);
+                let Some(id) = number.to_i64() else {
+                    continue;
+                };
+                if id as u32 != window_id {
+                    continue;
+                }
+            }
+
+            let bounds_ptr = CFDictionaryGetValue(
+                dict_ptr as CFDictionaryRef,
+                kCGWindowBounds as *const c_void,
+            );
+            if bounds_ptr.is_null() {
+                continue;
+            }
+
+            let mut rect = CGRect::new(&CGPoint::new(0., 0.), &CGSize::new(0., 0.));
+            let ok =
+                CGRectMakeWithDictionaryRepresentation(bounds_ptr as CFDictionaryRef, &mut rect);
+            if ok && rect.size.width > 1.0 && rect.size.height > 1.0 {
+                return Some(rect);
+            }
+        }
+    }
+    None
+}
+
+/// Display-local physical-pixel frame (top-left) for a window, plus monitor capture id.
+pub fn display_local_frame_for_window(
+    window_id: u32,
+    monitors: &[MonitorHandle],
+) -> Option<(u64, Frame)> {
+    let bounds = window_bounds_points(window_id)?;
+    let monitor = monitor_containing_point(
+        bounds.origin.x + bounds.size.width / 2.0,
+        bounds.origin.y + bounds.size.height / 2.0,
+        monitors,
+    )
+    .or_else(|| monitors.first())?;
+    let scale = monitor.scale_factor();
+    let pos = monitor.position();
+    let monitor_content_id = ScreenshareFunctions::capture_content_id_for_monitor(monitor)
+        .or_else(|| {
+            monitors
+                .first()
+                .and_then(ScreenshareFunctions::capture_content_id_for_monitor)
+        })?;
+
+    Some((
+        monitor_content_id,
+        frame_from_global_points(&bounds, scale, pos),
+    ))
+}
+
+/// Display-local physical frame given the capture monitor's scale and position.
+pub fn display_local_frame_on_monitor(
+    window_id: u32,
+    scale: f64,
+    display_position: PhysicalPosition<i32>,
+) -> Option<Frame> {
+    let bounds = window_bounds_points(window_id)?;
+    Some(frame_from_global_points(&bounds, scale, display_position))
+}
+
+fn frame_from_global_points(
+    bounds: &CGRect,
+    scale: f64,
+    display_position: PhysicalPosition<i32>,
+) -> Frame {
+    Frame {
+        origin_x: bounds.origin.x * scale - display_position.x as f64,
+        origin_y: bounds.origin.y * scale - display_position.y as f64,
+        extent: Extent {
+            width: bounds.size.width * scale,
+            height: bounds.size.height * scale,
+        },
+    }
+}
+
+fn monitor_containing_point<'a>(
+    point_x: f64,
+    point_y: f64,
+    monitors: &'a [MonitorHandle],
+) -> Option<&'a MonitorHandle> {
+    monitors.iter().find(|monitor| {
+        let scale = monitor.scale_factor();
+        let pos = monitor.position();
+        let size = monitor.size();
+        let left = pos.x as f64 / scale;
+        let top = pos.y as f64 / scale;
+        let right = left + size.width as f64 / scale;
+        let bottom = top + size.height as f64 / scale;
+        point_x >= left && point_x < right && point_y >= top && point_y < bottom
+    })
+}

--- a/core/src/capture/window_focus_macos.rs
+++ b/core/src/capture/window_focus_macos.rs
@@ -1,0 +1,40 @@
+//! Raise / activate a shareable macOS window so the user can interact with it.
+
+use objc2::rc::Retained;
+use objc2_app_kit::{NSApplicationActivationOptions, NSRunningApplication};
+use screencapturekit::prelude::*;
+
+/// Brings the application that owns `window_id` (SCWindow / CGWindow id) to the front.
+pub fn activate_window(window_id: u64) {
+    let Ok(content) = SCShareableContent::get() else {
+        log::warn!("activate_window: SCShareableContent::get failed");
+        return;
+    };
+    let Some(window) = content
+        .windows()
+        .into_iter()
+        .find(|window| window.window_id() as u64 == window_id)
+    else {
+        log::warn!("activate_window: window {window_id} not found");
+        return;
+    };
+    let Some(app) = window.owning_application() else {
+        log::warn!("activate_window: no owning application for window {window_id}");
+        return;
+    };
+
+    let pid = app.process_id();
+    let Some(running): Option<Retained<NSRunningApplication>> =
+        NSRunningApplication::runningApplicationWithProcessIdentifier(pid)
+    else {
+        log::warn!("activate_window: no NSRunningApplication for pid {pid}");
+        return;
+    };
+
+    let options = NSApplicationActivationOptions::ActivateAllWindows;
+    if !running.activateWithOptions(options) {
+        log::warn!("activate_window: activateWithOptions failed for pid {pid}");
+    } else {
+        log::info!("activate_window: activated pid {pid} for window {window_id}");
+    }
+}

--- a/core/src/capture/windows.rs
+++ b/core/src/capture/windows.rs
@@ -10,10 +10,10 @@ pub struct ScreenshareFunctions {}
 impl ScreenshareExt for ScreenshareFunctions {
     fn get_selected_monitor(
         monitors: &[winit::monitor::MonitorHandle],
-        input_id: u32,
+        input_id: u64,
     ) -> winit::monitor::MonitorHandle {
         let mut selected_monitor = monitors[0].clone();
-        let input_monitor_name = get_display_index(input_id);
+        let input_monitor_name = get_display_index(input_id as u32);
         for monitor in monitors {
             if monitor.native_id() == input_monitor_name {
                 selected_monitor = monitor.clone();
@@ -27,9 +27,9 @@ impl ScreenshareExt for ScreenshareFunctions {
         MonitorId::Named(monitor.native_id())
     }
 
-    fn capture_content_id_for_monitor(monitor: &winit::monitor::MonitorHandle) -> Option<u32> {
+    fn capture_content_id_for_monitor(monitor: &winit::monitor::MonitorHandle) -> Option<u64> {
         let monitor_name = monitor.native_id();
-        let mut index = 0;
+        let mut index = 0u32;
 
         loop {
             let display_name = get_display_index(index);
@@ -38,7 +38,7 @@ impl ScreenshareExt for ScreenshareFunctions {
             }
 
             if display_name == monitor_name {
-                return Some(index);
+                return Some(index as u64);
             }
 
             index += 1;
@@ -46,7 +46,6 @@ impl ScreenshareExt for ScreenshareFunctions {
     }
 }
 
-// TODO: Change name to this.
 fn get_display_index(input_id: u32) -> String {
     unsafe {
         let mut display_device = DISPLAY_DEVICEW {

--- a/core/src/graphics/graphics_context.rs
+++ b/core/src/graphics/graphics_context.rs
@@ -159,7 +159,7 @@ pub struct GraphicsContext<'a> {
     surface_alpha_mode: wgpu::CompositeAlphaMode,
     surface_present_mode: wgpu::PresentMode,
 
-    screen_selection: bool,
+    screen_selection: Option<crate::screen_selection::ScreenSelectionUi>,
 }
 
 impl<'a> GraphicsContext<'a> {
@@ -252,7 +252,7 @@ impl<'a> GraphicsContext<'a> {
             surface_format,
             surface_alpha_mode,
             surface_present_mode,
-            screen_selection: false,
+            screen_selection: None,
         })
     }
 
@@ -268,8 +268,29 @@ impl<'a> GraphicsContext<'a> {
         self.surface_format
     }
 
-    pub fn set_screen_selection(&mut self, screen_selection: bool) {
+    pub fn set_screen_selection(
+        &mut self,
+        screen_selection: Option<crate::screen_selection::ScreenSelectionUi>,
+    ) {
         self.screen_selection = screen_selection;
+    }
+
+    pub fn set_selection_cursor(&mut self, position: winit::dpi::PhysicalPosition<f64>) {
+        self.iced_renderer
+            .set_cursor_position(position, self.window.scale_factor());
+    }
+
+    pub fn handle_selection_click(
+        &mut self,
+    ) -> Vec<crate::graphics::graphics_context::iced_renderer::ScreenSelectionMessage> {
+        let Some(selection) = self.screen_selection.clone() else {
+            return Vec::new();
+        };
+        self.iced_renderer.handle_selection_click(
+            &selection,
+            &self.participants_manager,
+            &self.click_animation_renderer,
+        )
     }
 
     /// Returns a clone of the redraw thread sender for use by subsystems.
@@ -359,7 +380,11 @@ impl<'a> GraphicsContext<'a> {
     /// If frame acquisition fails (e.g., surface lost), the method logs the error
     /// and returns early without crashing. This provides resilience against
     /// temporary graphics driver issues or window state changes.
-    pub fn draw(&mut self, position_translator: &dyn Fn(Position) -> Position) {
+    pub fn draw(
+        &mut self,
+        position_translator: &dyn Fn(Position) -> Position,
+        marker_content: Option<crate::utils::geometry::Frame>,
+    ) {
         let output = match self.surface.get_current_texture() {
             Ok(output) => output,
             Err(e) => {
@@ -374,6 +399,12 @@ impl<'a> GraphicsContext<'a> {
         self.click_animation_renderer.update();
 
         let window_focused = self.window.has_focus();
+        let marker_content = marker_content.map(|frame| iced::Rectangle {
+            x: frame.origin_x as f32,
+            y: frame.origin_y as f32,
+            width: frame.extent.width as f32,
+            height: frame.extent.height as f32,
+        });
 
         self.iced_renderer.draw(iced_renderer::DrawArgs {
             frame: &output,
@@ -381,8 +412,9 @@ impl<'a> GraphicsContext<'a> {
             participants: &self.participants_manager,
             click_animation_renderer: &self.click_animation_renderer,
             position_translator,
-            screen_selection: self.screen_selection,
+            screen_selection: self.screen_selection.as_ref(),
             window_focused,
+            marker_content,
         });
 
         self.window.pre_present_notify();

--- a/core/src/graphics/iced_canvas.rs
+++ b/core/src/graphics/iced_canvas.rs
@@ -1,5 +1,5 @@
-use iced::widget::{canvas, column, container, text, Space};
-use iced::{mouse, Alignment, Background, Border, Color, Length, Padding, Rectangle, Theme};
+use iced::widget::{button, canvas, column, container, image, row, text, Space};
+use iced::{mouse, Alignment, Background, Border, Color, ContentFit, Length, Padding, Rectangle, Theme};
 use iced_wgpu::core::Element;
 
 #[path = "marker.rs"]
@@ -9,16 +9,23 @@ use marker::Marker;
 use crate::components::fonts::GEIST_REGULAR;
 use crate::graphics::graphics_context::click_animation::ClickAnimationRenderer;
 use crate::graphics::graphics_context::participant::ParticipantsManager;
+use crate::screen_selection::{ScreenSelectionItemUi, ScreenSelectionTab, ScreenSelectionUi};
 use crate::utils::geometry::Position;
 
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
-pub enum Message {}
+#[derive(Debug, Clone)]
+pub enum Message {
+    SelectTab(ScreenSelectionTab),
+    /// Clicking a tile immediately starts sharing that source.
+    ShareItem(usize),
+    Cancel,
+}
 
 pub struct OverlaySurfaceCanvas<'a> {
     marker: &'a Marker,
     participants: &'a ParticipantsManager,
     click_animation_renderer: &'a ClickAnimationRenderer,
     position_translator: &'a dyn Fn(Position) -> Position,
+    marker_content: Option<Rectangle>,
 }
 
 impl<'a> std::fmt::Debug for OverlaySurfaceCanvas<'a> {
@@ -33,12 +40,14 @@ impl<'a> OverlaySurfaceCanvas<'a> {
         participants: &'a ParticipantsManager,
         click_animation_renderer: &'a ClickAnimationRenderer,
         position_translator: &'a dyn Fn(Position) -> Position,
+        marker_content: Option<Rectangle>,
     ) -> Self {
         Self {
             marker,
             participants,
             click_animation_renderer,
             position_translator,
+            marker_content,
         }
     }
 }
@@ -54,7 +63,7 @@ impl<'a, Message> canvas::Program<Message> for OverlaySurfaceCanvas<'a> {
         bounds: Rectangle,
         _cursor: mouse::Cursor,
     ) -> Vec<canvas::Geometry> {
-        let mut geometries = vec![self.marker.draw(renderer, bounds)];
+        let mut geometries = vec![self.marker.draw(renderer, bounds, self.marker_content)];
         geometries.extend(
             self.participants
                 .draw(renderer, bounds, self.position_translator),
@@ -85,61 +94,335 @@ impl OverlaySurface {
         participants: &'a ParticipantsManager,
         click_animation_renderer: &'a ClickAnimationRenderer,
         position_translator: &'a dyn Fn(Position) -> Position,
-        screen_selection: bool,
+        screen_selection: Option<&'a ScreenSelectionUi>,
         window_focused: bool,
+        marker_content: Option<Rectangle>,
     ) -> Element<'a, Message, Theme, iced::Renderer> {
-        if screen_selection {
-            if !window_focused {
-                return Space::new().width(Length::Fill).height(Length::Fill).into();
-            }
-
-            let card_background = Color::from_rgba(0.28, 0.12, 0.58, 0.98);
-            let scrim_background = Color::from_rgba(0.08, 0.05, 0.20, 0.80);
-
-            let box_text = column![
-                text("Click anywhere to select this screen or press Enter")
-                    .size(26.0)
-                    .color(Color::from_rgb(0.98, 0.96, 1.0))
-                    .font(GEIST_REGULAR),
-                text("Move your cursor to the display you'd like to share (or use the arrows) and click. Press ESC to cancel.")
-                    .size(18.0)
-                    .color(Color::from_rgb(0.89, 0.84, 0.98))
-                    .font(GEIST_REGULAR),
-            ]
-            .spacing(16.0)
-            .max_width(460.0);
-
-            let box_container = container(box_text)
-                .padding(Padding::from([30.0, 40.0]))
-                .style(move |_theme: &Theme| container::Style {
-                    background: Some(Background::Color(card_background)),
-                    border: Border {
-                        radius: 16.0.into(),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                });
-
-            container(box_container)
-                .width(Length::Fill)
-                .height(Length::Fill)
-                .align_x(Alignment::Center)
-                .align_y(Alignment::Center)
-                .style(move |_theme: &Theme| container::Style {
-                    background: Some(Background::Color(scrim_background)),
-                    ..Default::default()
-                })
-                .into()
+        if let Some(selection) = screen_selection {
+            selection_view(selection, window_focused)
         } else {
             canvas(OverlaySurfaceCanvas::new(
                 &self.marker,
                 participants,
                 click_animation_renderer,
                 position_translator,
+                marker_content,
             ))
             .width(Length::Fill)
             .height(Length::Fill)
             .into()
         }
     }
+}
+
+fn selection_view<'a>(
+    selection: &'a ScreenSelectionUi,
+    window_focused: bool,
+) -> Element<'a, Message, Theme, iced::Renderer> {
+    if !window_focused {
+        return Space::new().width(Length::Fill).height(Length::Fill).into();
+    }
+
+    let scrim = Color::from_rgba(0.0, 0.0, 0.0, 0.55);
+    let card_bg = Color::from_rgb(0.14, 0.14, 0.16);
+    let tile_bg = Color::from_rgb(0.20, 0.20, 0.22);
+    let tile_selected = Color::from_rgb(0.18, 0.32, 0.55);
+    let accent = Color::from_rgb(0.20, 0.55, 0.95);
+    let text_primary = Color::from_rgb(0.96, 0.96, 0.97);
+    let text_muted = Color::from_rgb(0.70, 0.70, 0.74);
+    let tab_track = Color::from_rgb(0.22, 0.22, 0.25);
+
+    let screens_tab = segment_tab(
+        "Entire Screen",
+        selection.tab == ScreenSelectionTab::Screens,
+        accent,
+        text_primary,
+        text_muted,
+        Message::SelectTab(ScreenSelectionTab::Screens),
+    );
+    let windows_label = if selection.windows_supported {
+        "Window"
+    } else {
+        "Window (unavailable)"
+    };
+    let windows_tab = segment_tab(
+        windows_label,
+        selection.tab == ScreenSelectionTab::Windows,
+        accent,
+        text_primary,
+        text_muted,
+        Message::SelectTab(ScreenSelectionTab::Windows),
+    );
+
+    let tabs = container(
+        row![screens_tab, windows_tab]
+            .spacing(4.0)
+            .padding(4.0)
+            .width(Length::Fill),
+    )
+    .width(Length::Fill)
+    .style(move |_theme: &Theme| container::Style {
+        background: Some(Background::Color(tab_track)),
+        border: Border {
+            radius: 10.0.into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    let mut tiles = column![].spacing(10.0).width(Length::Fill);
+    if selection.items.is_empty() {
+        let empty_message = if selection.tab == ScreenSelectionTab::Windows {
+            selection
+                .windows_hint
+                .as_deref()
+                .unwrap_or("No windows available to share")
+        } else {
+            "No screens available"
+        };
+        tiles = tiles.push(
+            text(empty_message)
+                .size(15.0)
+                .color(text_muted)
+                .font(GEIST_REGULAR),
+        );
+    } else {
+        let mut row_tiles = row![].spacing(10.0).width(Length::Fill);
+        for (index, item) in selection.items.iter().enumerate() {
+            let tile = share_tile(
+                item,
+                index == selection.selected_index,
+                tile_bg,
+                tile_selected,
+                accent,
+                text_primary,
+                text_muted,
+                index,
+            );
+            row_tiles = row_tiles.push(tile);
+            if index % 2 == 1 {
+                tiles = tiles.push(row_tiles);
+                row_tiles = row![].spacing(10.0).width(Length::Fill);
+            }
+        }
+        if selection.items.len() % 2 == 1 {
+            row_tiles = row_tiles.push(Space::new().width(Length::Fill).height(Length::Shrink));
+            tiles = tiles.push(row_tiles);
+        }
+    }
+
+    let cancel = button(
+        text("Cancel")
+            .size(15.0)
+            .color(text_primary)
+            .font(GEIST_REGULAR),
+    )
+    .padding(Padding::from([10.0, 18.0]))
+    .style(move |_theme: &Theme, status| {
+        let hovered = matches!(status, iced::widget::button::Status::Hovered);
+        iced::widget::button::Style {
+            background: Some(Background::Color(if hovered {
+                Color::from_rgb(0.28, 0.28, 0.30)
+            } else {
+                Color::from_rgb(0.24, 0.24, 0.26)
+            })),
+            border: Border {
+                radius: 8.0.into(),
+                ..Default::default()
+            },
+            text_color: text_primary,
+            ..Default::default()
+        }
+    })
+    .on_press(Message::Cancel);
+
+    let actions = row![
+        text("Click a screen or window to start sharing")
+            .size(13.0)
+            .color(text_muted)
+            .font(GEIST_REGULAR),
+        Space::new().width(Length::Fill).height(Length::Shrink),
+        cancel,
+    ]
+    .spacing(10.0)
+    .align_y(Alignment::Center)
+    .width(Length::Fill);
+
+    let body = column![
+        text("Choose what to share")
+            .size(22.0)
+            .color(text_primary)
+            .font(GEIST_REGULAR),
+        text("Your screen or a single application window")
+            .size(14.0)
+            .color(text_muted)
+            .font(GEIST_REGULAR),
+        tabs,
+        tiles,
+        actions,
+    ]
+    .spacing(16.0)
+    .max_width(640.0);
+
+    let card = container(body)
+        .padding(Padding::from([28.0, 28.0]))
+        .style(move |_theme: &Theme| container::Style {
+            background: Some(Background::Color(card_bg)),
+            border: Border {
+                radius: 14.0.into(),
+                width: 1.0,
+                color: Color::from_rgba(1.0, 1.0, 1.0, 0.08),
+            },
+            ..Default::default()
+        });
+
+    container(card)
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .align_x(Alignment::Center)
+        .align_y(Alignment::Center)
+        .style(move |_theme: &Theme| container::Style {
+            background: Some(Background::Color(scrim)),
+            ..Default::default()
+        })
+        .into()
+}
+
+fn share_tile<'a>(
+    item: &'a ScreenSelectionItemUi,
+    selected: bool,
+    tile_bg: Color,
+    tile_selected: Color,
+    accent: Color,
+    text_primary: Color,
+    text_muted: Color,
+    index: usize,
+) -> Element<'a, Message, Theme, iced::Renderer> {
+    let preview: Element<'a, Message, Theme, iced::Renderer> =
+        if let Some(handle) = item.thumbnail.clone() {
+            container(
+                image(handle)
+                    .width(Length::Fill)
+                    .height(Length::Fill)
+                    .content_fit(ContentFit::Cover),
+            )
+            .width(Length::Fill)
+            .height(Length::Fixed(110.0))
+            .style(move |_theme: &Theme| container::Style {
+                background: Some(Background::Color(Color::from_rgb(0.10, 0.10, 0.12))),
+                border: Border {
+                    radius: 8.0.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .into()
+        } else {
+            container(
+                text("No preview")
+                    .size(12.0)
+                    .color(text_muted)
+                    .font(GEIST_REGULAR),
+            )
+            .width(Length::Fill)
+            .height(Length::Fixed(110.0))
+            .center_x(Length::Fill)
+            .center_y(Length::Fill)
+            .style(move |_theme: &Theme| container::Style {
+                background: Some(Background::Color(Color::from_rgb(0.10, 0.10, 0.12))),
+                border: Border {
+                    radius: 8.0.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .into()
+        };
+
+    let mut labels = column![
+        text(&item.title)
+            .size(14.0)
+            .color(text_primary)
+            .font(GEIST_REGULAR),
+    ]
+    .spacing(2.0)
+    .width(Length::Fill);
+
+    if let Some(subtitle) = item.subtitle.as_deref() {
+        labels = labels.push(
+            text(subtitle)
+                .size(12.0)
+                .color(text_muted)
+                .font(GEIST_REGULAR),
+        );
+    }
+
+    let content = column![preview, labels].spacing(8.0).width(Length::Fill);
+
+    button(content)
+        .padding(Padding::from([10.0, 10.0]))
+        .width(Length::Fill)
+        .style(move |_theme: &Theme, status| {
+            let hovered = matches!(status, iced::widget::button::Status::Hovered);
+            iced::widget::button::Style {
+                background: Some(Background::Color(if selected {
+                    tile_selected
+                } else if hovered {
+                    Color::from_rgb(0.24, 0.24, 0.27)
+                } else {
+                    tile_bg
+                })),
+                border: Border {
+                    radius: 10.0.into(),
+                    width: if selected || hovered { 2.0 } else { 1.0 },
+                    color: if selected || hovered {
+                        accent
+                    } else {
+                        Color::from_rgba(1.0, 1.0, 1.0, 0.06)
+                    },
+                },
+                text_color: text_primary,
+                ..Default::default()
+            }
+        })
+        .on_press(Message::ShareItem(index))
+        .into()
+}
+
+fn segment_tab<'a>(
+    label: &'a str,
+    active: bool,
+    accent: Color,
+    text_primary: Color,
+    text_muted: Color,
+    message: Message,
+) -> Element<'a, Message, Theme, iced::Renderer> {
+    button(
+        text(label)
+            .size(14.0)
+            .color(if active { text_primary } else { text_muted })
+            .font(GEIST_REGULAR),
+    )
+    .padding(Padding::from([8.0, 12.0]))
+    .width(Length::Fill)
+    .style(move |_theme: &Theme, _status| iced::widget::button::Style {
+        background: if active {
+            Some(Background::Color(Color::from_rgb(0.30, 0.30, 0.34)))
+        } else {
+            None
+        },
+        border: Border {
+            radius: 8.0.into(),
+            width: if active { 1.0 } else { 0.0 },
+            color: if active {
+                accent
+            } else {
+                Color::TRANSPARENT
+            },
+        },
+        text_color: if active { text_primary } else { text_muted },
+        ..Default::default()
+    })
+    .on_press(message)
+    .into()
 }

--- a/core/src/graphics/iced_renderer.rs
+++ b/core/src/graphics/iced_renderer.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::components::fonts as fonts_mod;
 use crate::graphics::graphics_window_context::ContextManager;
+use crate::screen_selection::ScreenSelectionUi;
 use crate::utils::geometry::Position;
 use iced::Renderer;
 use iced::{Font, Pixels};
@@ -13,14 +14,17 @@ use iced_winit::{
     runtime::{user_interface, UserInterface},
     Clipboard,
 };
+use winit::dpi::PhysicalPosition;
 use winit::window::Window;
 
 #[path = "iced_canvas.rs"]
 mod iced_canvas;
-use iced_canvas::OverlaySurface;
+use iced_canvas::{Message as SelectionMessage, OverlaySurface};
 
 use super::click_animation::ClickAnimationRenderer;
 use super::participant::ParticipantsManager;
+
+pub use iced_canvas::Message as ScreenSelectionMessage;
 
 #[derive(Clone, Copy)]
 pub struct DrawArgs<'a> {
@@ -29,8 +33,9 @@ pub struct DrawArgs<'a> {
     pub participants: &'a ParticipantsManager,
     pub click_animation_renderer: &'a ClickAnimationRenderer,
     pub position_translator: &'a dyn Fn(Position) -> Position,
-    pub screen_selection: bool,
+    pub screen_selection: Option<&'a ScreenSelectionUi>,
     pub window_focused: bool,
+    pub marker_content: Option<iced::Rectangle>,
 }
 
 pub struct IcedRenderer {
@@ -88,6 +93,51 @@ impl IcedRenderer {
         );
     }
 
+    pub fn set_cursor_position(&mut self, position: PhysicalPosition<f64>, scale_factor: f64) {
+        let logical = iced::Point::new(
+            (position.x / scale_factor) as f32,
+            (position.y / scale_factor) as f32,
+        );
+        self.cursor = mouse::Cursor::Available(logical);
+    }
+
+    /// Runs a left-click through the selection UI and returns iced messages.
+    pub fn handle_selection_click(
+        &mut self,
+        selection: &ScreenSelectionUi,
+        participants: &ParticipantsManager,
+        click_animation_renderer: &ClickAnimationRenderer,
+    ) -> Vec<SelectionMessage> {
+        let mut messages = Vec::new();
+        let identity = |p: Position| p;
+        let mut interface = UserInterface::build(
+            self.overlay_surface.view(
+                participants,
+                click_animation_renderer,
+                &identity,
+                Some(selection),
+                true,
+                None,
+            ),
+            self.viewport.logical_size(),
+            user_interface::Cache::default(),
+            &mut self.renderer,
+        );
+
+        let events = [
+            Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+            Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left)),
+        ];
+        let _ = interface.update(
+            &events,
+            self.cursor,
+            &mut self.renderer,
+            &mut self.clipboard,
+            &mut messages,
+        );
+        messages
+    }
+
     pub fn draw(&mut self, args: DrawArgs) {
         let DrawArgs {
             frame,
@@ -97,6 +147,7 @@ impl IcedRenderer {
             position_translator,
             screen_selection,
             window_focused,
+            marker_content,
         } = args;
 
         let mut interface = UserInterface::build(
@@ -106,6 +157,7 @@ impl IcedRenderer {
                 position_translator,
                 screen_selection,
                 window_focused,
+                marker_content,
             ),
             self.viewport.logical_size(),
             user_interface::Cache::default(),

--- a/core/src/graphics/marker.rs
+++ b/core/src/graphics/marker.rs
@@ -1,65 +1,102 @@
-use iced::{widget::canvas, Rectangle, Renderer};
+use iced::widget::canvas::{self, path, stroke, Path, Stroke};
+use iced::{Color, Point, Rectangle, Renderer};
 
 pub struct Marker {
-    marker: iced_core::image::Handle,
     cache: canvas::Cache,
 }
 
 impl Marker {
-    pub fn new(texture_path: &String) -> Self {
-        let cache = canvas::Cache::new();
-        let marker =
-            iced_core::image::Handle::from_path(format!("{texture_path}/marker_top_left.png"));
-        Self { marker, cache }
+    pub fn new(_texture_path: &String) -> Self {
+        Self {
+            cache: canvas::Cache::new(),
+        }
     }
 
-    pub fn draw(&self, renderer: &Renderer, bounds: Rectangle) -> canvas::Geometry {
+    /// Draws corner marks around `content` when provided, otherwise around `bounds`.
+    pub fn draw(
+        &self,
+        renderer: &Renderer,
+        bounds: Rectangle,
+        content: Option<Rectangle>,
+    ) -> canvas::Geometry {
+        // Content rect changes without bounds size changing (window vs display share),
+        // so clear the cache to avoid stale corner positions.
+        self.cache.clear();
+        let content = content
+            .filter(|rect| rect.width > 0.0 && rect.height > 0.0)
+            .unwrap_or(bounds);
+
         self.cache.draw(renderer, bounds.size(), |frame| {
-            let image_handle = iced_core::image::Image::new(self.marker.clone());
-            let width = 40.0;
-            let height = 40.0;
-            frame.draw_image(
-                Rectangle {
-                    x: 0.,
-                    y: 0.,
-                    width,
-                    height,
-                },
-                image_handle,
+            let arm = 28.0_f32;
+            let radius = 8.0_f32;
+            let stroke = Stroke {
+                style: stroke::Style::Solid(Color::from_rgb(1.0, 0.0, 1.0)),
+                width: 3.0,
+                line_cap: stroke::LineCap::Round,
+                line_join: stroke::LineJoin::Round,
+                line_dash: stroke::LineDash::default(),
+            };
+
+            let left = content.x;
+            let top = content.y;
+            let right = content.x + content.width;
+            let bottom = content.y + content.height;
+
+            frame.stroke(&rounded_corner(left, top, arm, radius, Corner::TopLeft), stroke);
+            frame.stroke(
+                &rounded_corner(right, top, arm, radius, Corner::TopRight),
+                stroke,
             );
-            let image_handle = iced_core::image::Image::new(self.marker.clone());
-            let image_handle = image_handle.rotation(iced_core::Radians::PI * 1.5);
-            frame.draw_image(
-                Rectangle {
-                    x: 0.,
-                    y: bounds.height - height,
-                    width,
-                    height,
-                },
-                image_handle,
+            frame.stroke(
+                &rounded_corner(left, bottom, arm, radius, Corner::BottomLeft),
+                stroke,
             );
-            let image_handle = iced_core::image::Image::new(self.marker.clone());
-            let image_handle = image_handle.rotation(iced_core::Radians::PI);
-            frame.draw_image(
-                Rectangle {
-                    x: bounds.width - width,
-                    y: bounds.height - height,
-                    width,
-                    height,
-                },
-                image_handle,
-            );
-            let image_handle = iced_core::image::Image::new(self.marker.clone());
-            let image_handle = image_handle.rotation(iced_core::Radians::PI / 2.0);
-            frame.draw_image(
-                Rectangle {
-                    x: bounds.width - width,
-                    y: 0.,
-                    width,
-                    height,
-                },
-                image_handle,
+            frame.stroke(
+                &rounded_corner(right, bottom, arm, radius, Corner::BottomRight),
+                stroke,
             );
         })
     }
+}
+
+#[derive(Clone, Copy)]
+enum Corner {
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+
+fn rounded_corner(x: f32, y: f32, arm: f32, radius: f32, corner: Corner) -> Path {
+    let radius = radius.min(arm * 0.45);
+    let mut builder = path::Builder::new();
+
+    match corner {
+        Corner::TopLeft => {
+            builder.move_to(Point::new(x, y + arm));
+            builder.line_to(Point::new(x, y + radius));
+            builder.quadratic_curve_to(Point::new(x, y), Point::new(x + radius, y));
+            builder.line_to(Point::new(x + arm, y));
+        }
+        Corner::TopRight => {
+            builder.move_to(Point::new(x - arm, y));
+            builder.line_to(Point::new(x - radius, y));
+            builder.quadratic_curve_to(Point::new(x, y), Point::new(x, y + radius));
+            builder.line_to(Point::new(x, y + arm));
+        }
+        Corner::BottomLeft => {
+            builder.move_to(Point::new(x, y - arm));
+            builder.line_to(Point::new(x, y - radius));
+            builder.quadratic_curve_to(Point::new(x, y), Point::new(x + radius, y));
+            builder.line_to(Point::new(x + arm, y));
+        }
+        Corner::BottomRight => {
+            builder.move_to(Point::new(x - arm, y));
+            builder.line_to(Point::new(x - radius, y));
+            builder.quadratic_curve_to(Point::new(x, y), Point::new(x, y - radius));
+            builder.line_to(Point::new(x, y - arm));
+        }
+    }
+
+    builder.build()
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -29,7 +29,15 @@ pub mod camera {
 
 pub mod capture {
     pub mod capturer;
+    pub mod sources;
+    pub mod thumbnail;
+    #[cfg(target_os = "macos")]
+    pub mod window_bounds_macos;
+    #[cfg(target_os = "macos")]
+    pub mod window_focus_macos;
 }
+
+pub mod screen_selection;
 
 pub mod graphics {
     pub mod graphics_context;
@@ -69,8 +77,8 @@ use log::{debug, error};
 use overlay_window::OverlayWindow;
 use room_service::RoomService;
 use socket_lib::{
-    CallStartMessage, CameraStartMessage, Content, ContentType, Message, ScreenShareMessage,
-    ScreenShareResolution, SentryMetadata, SocketSender,
+    CallStartMessage, CameraStartMessage, ContentType, Message, ScreenShareMessage,
+    ScreenShareResolution, SentryMetadata, SocketSender, WindowFrame,
 };
 use std::fmt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -93,9 +101,12 @@ use window::screensharing_window::ScreenShareInputEvent;
 #[cfg(target_os = "macos")]
 use winit::platform::macos::EventLoopBuilderExtMacOS;
 
+use crate::graphics::graphics_context::iced_renderer::ScreenSelectionMessage;
 use crate::overlay_window::DisplayInfo;
 use crate::room_service::DrawingMode;
+use crate::screen_selection::{ScreenSelectionState, ScreenSelectionTab};
 use crate::utils::geometry::Position;
+use crate::window_manager::ScreenSelectionNavigationDirection;
 
 /// Process exit code for errors
 const PROCESS_EXIT_CODE_ERROR: i32 = 1;
@@ -156,11 +167,10 @@ impl RemoteControl {
             .update_cursors(gfx.participants_manager_mut());
         self.cursor_controller.hide_inactive_cursors();
         let cleared_path_ids = gfx.participants_manager_mut().update_auto_clear();
-        let translator = self
-            .cursor_controller
-            .get_overlay_window()
-            .create_position_translator();
-        gfx.draw(&translator);
+        let overlay = self.cursor_controller.get_overlay_window();
+        let translator = overlay.create_position_translator();
+        let marker_content = overlay.sharing_frame_logical();
+        gfx.draw(&translator, marker_content);
         cleared_path_ids
     }
 }
@@ -239,6 +249,7 @@ pub struct Application<'a> {
     remote_control_enabled: bool,
     clipboard_controller: Option<ClipboardController>,
     screen_selection_active: bool,
+    screen_selection_state: Option<ScreenSelectionState>,
 }
 
 #[derive(Error, Debug)]
@@ -327,11 +338,12 @@ impl<'a> Application<'a> {
             remote_control_enabled: true,
             clipboard_controller,
             screen_selection_active: false,
+            screen_selection_state: None,
         })
     }
 
     fn start_screen_selection(&mut self, event_loop: &ActiveEventLoop) {
-        log::info!("start_screen_selection: opening screen selection overlays");
+        log::info!("start_screen_selection: opening share source picker");
 
         let Some(window_manager) = self.window_manager.as_mut() else {
             log::error!("start_screen_selection: window manager not initialized");
@@ -346,8 +358,13 @@ impl<'a> Application<'a> {
             log::warn!("start_screen_selection: context manager not initialized");
         }
 
+        let monitors: Vec<MonitorHandle> = event_loop.available_monitors().collect();
+        let selection = ScreenSelectionState::new(&monitors);
+        let ui = selection.ui_snapshot();
+        self.screen_selection_state = Some(selection);
         self.screen_selection_active = true;
         window_manager.show_screen_selection(event_loop);
+        window_manager.update_screen_selection_ui(Some(ui));
     }
 
     /// Initiates a screen sharing session with the specified configuration.
@@ -407,8 +424,23 @@ impl<'a> Application<'a> {
             }
         };
 
-        let monitor = screen_capturer.get_selected_monitor(&monitors, screenshare_input.content.id);
+        let monitor_id = screenshare_input
+            .monitor_id
+            .unwrap_or(screenshare_input.content.id);
+        let monitor = screen_capturer.get_selected_monitor(&monitors, monitor_id);
         let scale = monitor.scale_factor();
+
+        let window_frame = screenshare_input
+            .window_frame
+            .map(|frame| Frame {
+                origin_x: frame.origin_x,
+                origin_y: frame.origin_y,
+                extent: Extent {
+                    width: frame.width,
+                    height: frame.height,
+                },
+            })
+            .unwrap_or_default();
 
         let res = screen_capturer.start_capture(
             screenshare_input.content,
@@ -418,6 +450,7 @@ impl<'a> Application<'a> {
             },
             buffer_source,
             scale,
+            monitor.position(),
         );
         if let Err(error) = res {
             log::error!("screenshare: error starting capture: {error:?}");
@@ -436,7 +469,7 @@ impl<'a> Application<'a> {
 
         drop(screen_capturer);
 
-        let res = self.create_overlay_window(monitor, self.remote_control_enabled);
+        let res = self.create_overlay_window(monitor, self.remote_control_enabled, window_frame);
         if let Err(e) = res {
             self.stop_screenshare();
             log::error!("screenshare: error creating overlay window: {e:?}");
@@ -621,30 +654,174 @@ impl<'a> Application<'a> {
             window_manager.hide_screen_selection();
         }
         self.screen_selection_active = false;
+        self.screen_selection_state = None;
     }
 
-    fn select_screen_selection_window(
+    fn refresh_screen_selection_ui(&mut self) {
+        let ui = self
+            .screen_selection_state
+            .as_ref()
+            .map(ScreenSelectionState::ui_snapshot);
+        if let Some(window_manager) = self.window_manager.as_mut() {
+            window_manager.update_screen_selection_ui(ui);
+        }
+    }
+
+    /// Focuses the selection overlay for `window_id` and, on the Screens tab,
+    /// syncs the selected display to that monitor.
+    fn focus_screen_selection_window(
         &mut self,
         event_loop: &ActiveEventLoop,
         window_id: winit::window::WindowId,
     ) {
-        let Some(message) = self.screenshare_message_for_window(event_loop, window_id) else {
-            log::error!("select_screen_selection_window: failed to resolve selected screen");
+        let Some(window_manager) = self.window_manager.as_ref() else {
             return;
+        };
+
+        if !window_manager.focus_window(window_id) {
+            log::warn!("focus_screen_selection_window: failed to focus window");
+            return;
+        }
+
+        let Some(monitor_id) = window_manager.monitor_id_for_window(window_id) else {
+            return;
+        };
+
+        let monitor_content_id = event_loop.available_monitors().find_map(|monitor| {
+            if ScreenshareFunctions::get_monitor_id(&monitor) == monitor_id {
+                ScreenshareFunctions::capture_content_id_for_monitor(&monitor)
+            } else {
+                None
+            }
+        });
+
+        let mut selection_changed = false;
+        if let (Some(monitor_content_id), Some(selection)) =
+            (monitor_content_id, self.screen_selection_state.as_mut())
+        {
+            selection_changed = selection.select_display_for_monitor(monitor_content_id);
+        }
+
+        if selection_changed {
+            self.refresh_screen_selection_ui();
+        } else if let Some(window_manager) = self.window_manager.as_mut() {
+            for gfx in window_manager.all_gfx_mut() {
+                gfx.trigger_render();
+            }
+        }
+    }
+
+    fn navigate_screen_selection(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        direction: ScreenSelectionNavigationDirection,
+    ) {
+        let on_windows_tab = self
+            .screen_selection_state
+            .as_ref()
+            .is_some_and(|selection| selection.tab == ScreenSelectionTab::Windows);
+
+        // On the Windows tab, vertical arrows move the window list; horizontal
+        // arrows (and all arrows on Screens) move focus across monitors.
+        if on_windows_tab
+            && matches!(
+                direction,
+                ScreenSelectionNavigationDirection::Up | ScreenSelectionNavigationDirection::Down
+            )
+        {
+            let delta = match direction {
+                ScreenSelectionNavigationDirection::Up => -1,
+                ScreenSelectionNavigationDirection::Down => 1,
+                _ => 0,
+            };
+            if let Some(selection) = self.screen_selection_state.as_mut() {
+                selection.move_selection(delta);
+            }
+            self.refresh_screen_selection_ui();
+            return;
+        }
+
+        let Some(target_window_id) = self.window_manager.as_ref().and_then(|window_manager| {
+            window_manager.focus_window_in_direction(window_id, direction)
+        }) else {
+            return;
+        };
+
+        self.focus_screen_selection_window(event_loop, target_window_id);
+    }
+
+    fn handle_screen_selection_message(&mut self, message: ScreenSelectionMessage) {
+        match message {
+            ScreenSelectionMessage::SelectTab(tab) => {
+                if let Some(selection) = self.screen_selection_state.as_mut() {
+                    selection.set_tab(tab);
+                }
+                self.refresh_screen_selection_ui();
+            }
+            ScreenSelectionMessage::ShareItem(index) => {
+                if let Some(selection) = self.screen_selection_state.as_mut() {
+                    if !selection.select_index(index) {
+                        return;
+                    }
+                }
+                self.confirm_screen_selection();
+            }
+            ScreenSelectionMessage::Cancel => {
+                self.cancel_screen_selection();
+            }
+        }
+    }
+
+    fn confirm_screen_selection(&mut self) {
+        let Some(source) = self
+            .screen_selection_state
+            .as_ref()
+            .and_then(ScreenSelectionState::selected)
+            .cloned()
+        else {
+            log::warn!("confirm_screen_selection: no source selected");
+            return;
+        };
+
+        #[cfg(target_os = "macos")]
+        if source.content.content_type == ContentType::Window {
+            crate::capture::window_focus_macos::activate_window(source.content.id);
+        }
+
+        let resolution = self.screen_share_resolution.extent();
+        let window_frame = if source.content.content_type == ContentType::Window
+            && source.frame.extent.width > 0.
+            && source.frame.extent.height > 0.
+        {
+            Some(WindowFrame {
+                origin_x: source.frame.origin_x,
+                origin_y: source.frame.origin_y,
+                width: source.frame.extent.width,
+                height: source.frame.extent.height,
+            })
+        } else {
+            None
+        };
+
+        let message = ScreenShareMessage {
+            content: source.content,
+            resolution,
+            monitor_id: Some(source.monitor_content_id),
+            window_frame,
         };
 
         if let Some(window_manager) = self.window_manager.as_mut() {
             window_manager.hide_screen_selection();
         }
         self.screen_selection_active = false;
+        self.screen_selection_state = None;
 
         if let Err(error) = self
             .event_loop_proxy
             .send_event(UserEvent::ScreenShare(message))
         {
-            log::error!(
-                "select_screen_selection_window: failed to send ScreenShare event: {error:?}"
-            );
+            log::error!("confirm_screen_selection: failed to send ScreenShare event: {error:?}");
         }
     }
 
@@ -652,9 +829,10 @@ impl<'a> Application<'a> {
         &mut self,
         selected_monitor: MonitorHandle,
         remote_control_enabled: bool,
+        window_frame: Frame,
     ) -> Result<(), ServerError> {
         log::info!(
-            "create_overlay_window: selected_monitor: {selected_monitor:?} {remote_control_enabled}",
+            "create_overlay_window: selected_monitor: {selected_monitor:?} {remote_control_enabled} frame: {window_frame}",
         );
 
         let window = self
@@ -670,8 +848,6 @@ impl<'a> Application<'a> {
         let window_size = window.inner_size();
         let window_outer_position = window.outer_position();
 
-        /* Hardcode window frame to zero as we only support displays for now.*/
-        let window_frame = Frame::default();
         let scaled = {
             #[cfg(target_os = "macos")]
             {
@@ -747,33 +923,6 @@ impl<'a> Application<'a> {
             wm.hide_active_window();
         }
         self.remote_control = None;
-    }
-
-    fn screenshare_message_for_window(
-        &self,
-        event_loop: &ActiveEventLoop,
-        window_id: winit::window::WindowId,
-    ) -> Option<ScreenShareMessage> {
-        let clicked_monitor_id = self
-            .window_manager
-            .as_ref()?
-            .monitor_id_for_window(window_id)?;
-
-        let monitor = event_loop
-            .available_monitors()
-            .find(|monitor| ScreenshareFunctions::get_monitor_id(monitor) == clicked_monitor_id)?;
-
-        let content_id = ScreenshareFunctions::capture_content_id_for_monitor(&monitor)?;
-
-        let resolution = self.screen_share_resolution.extent();
-
-        Some(ScreenShareMessage {
-            content: Content {
-                content_type: ContentType::Display,
-                id: content_id,
-            },
-            resolution,
-        })
     }
 }
 
@@ -1069,8 +1218,9 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                 log::debug!("user_event: Screen share: {data:?}");
                 if let Some(ref mut wm) = self.window_manager {
                     wm.hide_screen_selection();
-                    self.screen_selection_active = false;
                 }
+                self.screen_selection_active = false;
+                self.screen_selection_state = None;
                 let monitors = event_loop
                     .available_monitors()
                     .collect::<Vec<MonitorHandle>>();
@@ -2228,7 +2378,7 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     let all_gfx = window_manager.all_gfx_mut();
                     for gfx in all_gfx {
                         let dummy_translator = move |pos: Position| pos;
-                        gfx.draw(&dummy_translator);
+                        gfx.draw(&dummy_translator, None);
                     }
 
                     return;
@@ -2248,6 +2398,16 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     return;
                 };
 
+                // Sync live capture bounds so corner marks track the shared window.
+                if let Ok(capturer) = self.screen_capturer.lock() {
+                    if let Some(frame) = capturer.get_capture_frame() {
+                        remote_control
+                            .cursor_controller
+                            .get_overlay_window()
+                            .set_sharing_window_frame(frame);
+                    }
+                }
+
                 // Render frame with cursor updates, auto-clear, and drawing
                 let cleared_path_ids = remote_control.render_frame(gfx);
 
@@ -2259,24 +2419,28 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                     _ => {}
                 }
             }
+            WindowEvent::CursorMoved { position, .. } if self.screen_selection_active => {
+                if let Some(window_manager) = self.window_manager.as_mut() {
+                    window_manager.set_selection_cursor(window_id, position);
+                }
+            }
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Left,
                 ..
             } if self.screen_selection_active => {
-                self.select_screen_selection_window(event_loop, window_id);
+                self.focus_screen_selection_window(event_loop, window_id);
+                let messages = self
+                    .window_manager
+                    .as_mut()
+                    .map(|window_manager| window_manager.handle_selection_click(window_id))
+                    .unwrap_or_default();
+                for message in messages {
+                    self.handle_screen_selection_message(message);
+                }
             }
             WindowEvent::CursorEntered { .. } if self.screen_selection_active => {
-                if let Some(window_manager) = self.window_manager.as_ref() {
-                    if !window_manager.focus_window(window_id) {
-                        log::warn!("window_event: failed to focus screen selection window");
-                    }
-                }
-                if let Some(window_manager) = self.window_manager.as_mut() {
-                    for gfx in window_manager.all_gfx_mut() {
-                        gfx.trigger_render();
-                    }
-                }
+                self.focus_screen_selection_window(event_loop, window_id);
             }
             WindowEvent::KeyboardInput { event, .. }
                 if self.screen_selection_active && event.state.is_pressed() =>
@@ -2287,40 +2451,43 @@ impl<'a> ApplicationHandler<UserEvent> for Application<'a> {
                         self.cancel_screen_selection();
                     }
                     Key::Named(NamedKey::Enter) => {
-                        log::info!("window_event: Enter, selecting focused screen");
-                        self.select_screen_selection_window(event_loop, window_id);
+                        log::info!("window_event: Enter, confirming share selection");
+                        self.focus_screen_selection_window(event_loop, window_id);
+                        self.confirm_screen_selection();
+                    }
+                    Key::Named(NamedKey::Tab) => {
+                        if let Some(selection) = self.screen_selection_state.as_mut() {
+                            selection.toggle_tab();
+                        }
+                        self.refresh_screen_selection_ui();
                     }
                     Key::Named(NamedKey::ArrowLeft) => {
-                        if let Some(window_manager) = self.window_manager.as_ref() {
-                            window_manager.focus_window_in_direction(
-                                window_id,
-                                window_manager::ScreenSelectionNavigationDirection::Left,
-                            );
-                        }
+                        self.navigate_screen_selection(
+                            event_loop,
+                            window_id,
+                            ScreenSelectionNavigationDirection::Left,
+                        );
                     }
                     Key::Named(NamedKey::ArrowRight) => {
-                        if let Some(window_manager) = self.window_manager.as_ref() {
-                            window_manager.focus_window_in_direction(
-                                window_id,
-                                window_manager::ScreenSelectionNavigationDirection::Right,
-                            );
-                        }
+                        self.navigate_screen_selection(
+                            event_loop,
+                            window_id,
+                            ScreenSelectionNavigationDirection::Right,
+                        );
                     }
                     Key::Named(NamedKey::ArrowUp) => {
-                        if let Some(window_manager) = self.window_manager.as_ref() {
-                            window_manager.focus_window_in_direction(
-                                window_id,
-                                window_manager::ScreenSelectionNavigationDirection::Up,
-                            );
-                        }
+                        self.navigate_screen_selection(
+                            event_loop,
+                            window_id,
+                            ScreenSelectionNavigationDirection::Up,
+                        );
                     }
                     Key::Named(NamedKey::ArrowDown) => {
-                        if let Some(window_manager) = self.window_manager.as_ref() {
-                            window_manager.focus_window_in_direction(
-                                window_id,
-                                window_manager::ScreenSelectionNavigationDirection::Down,
-                            );
-                        }
+                        self.navigate_screen_selection(
+                            event_loop,
+                            window_id,
+                            ScreenSelectionNavigationDirection::Down,
+                        );
                     }
                     _ => {}
                 }

--- a/core/src/overlay_window.rs
+++ b/core/src/overlay_window.rs
@@ -6,6 +6,7 @@
 //! accurate coordinate mapping for virtual cursors.
 
 use core::fmt;
+use std::sync::Mutex;
 
 use winit::dpi::PhysicalPosition;
 
@@ -32,8 +33,8 @@ pub struct DisplayInfo {
 /// It is used for properly showing the virtual cursor in the correct position and
 /// translating to global coordinates from display local when simulating mouse events.
 pub struct OverlayWindow {
-    /* The frame of the window/display being shared. */
-    sharing_window_frame: Frame,
+    /* The frame of the window/display being shared (physical pixels, display-local). */
+    sharing_window_frame: Mutex<Frame>,
     /* The window's dimensions in pixels. */
     extent: Extent,
     /* The window's position in global coordinates (pixels). */
@@ -53,14 +54,14 @@ impl OverlayWindow {
     /// A new `OverlayWindow` instance with default values.
     pub fn default() -> Self {
         Self {
-            sharing_window_frame: Frame {
+            sharing_window_frame: Mutex::new(Frame {
                 origin_x: 0.,
                 origin_y: 0.,
                 extent: Extent {
                     width: 0.0,
                     height: 0.0,
                 },
-            },
+            }),
             extent: Extent {
                 width: 0.0,
                 height: 0.0,
@@ -102,12 +103,22 @@ impl OverlayWindow {
         scaled: bool,
     ) -> Self {
         Self {
-            sharing_window_frame,
+            sharing_window_frame: Mutex::new(sharing_window_frame),
             extent,
             position,
             display_info,
             scaled,
         }
+    }
+
+    /// Updates the shared-content frame so overlays (markers, cursor mapping) track
+    /// a moving/resizing window.
+    pub fn set_sharing_window_frame(&self, frame: Frame) {
+        *self.sharing_window_frame.lock().unwrap() = frame;
+    }
+
+    fn sharing_frame(&self) -> Frame {
+        *self.sharing_window_frame.lock().unwrap()
     }
 
     /// Translates window local percentage coordinates to screen percentage coordinates.
@@ -131,20 +142,19 @@ impl OverlayWindow {
     pub fn translate_location(&self, x: f64, y: f64) -> Position {
         log::debug!("translate_location: x: {x}, y: {y}");
 
-        if self.sharing_window_frame.extent.width == 0.0
-            || self.sharing_window_frame.extent.height == 0.0
-        {
+        let sharing = self.sharing_frame();
+        if sharing.extent.width == 0.0 || sharing.extent.height == 0.0 {
             log::debug!("translate_point: client_frame extent is 0.0");
             return Position { x, y };
         }
 
         /* The following is unused. It will be needed when we support individual window sharing. */
-        let width_ratio = self.sharing_window_frame.extent.width / self.extent.width;
-        let width_offset = self.sharing_window_frame.origin_x / self.extent.width;
+        let width_ratio = sharing.extent.width / self.extent.width;
+        let width_offset = sharing.origin_x / self.extent.width;
         let x = x * width_ratio + width_offset;
 
-        let height_ratio = (self.sharing_window_frame.extent.height / self.extent.height).min(1.0);
-        let height_offset = self.sharing_window_frame.origin_y / self.extent.height;
+        let height_ratio = (sharing.extent.height / self.extent.height).min(1.0);
+        let height_offset = sharing.origin_y / self.extent.height;
         let y = y * height_ratio + height_offset;
 
         if !(0.0..=1.0).contains(&x) || !(0.0..=1.0).contains(&y) {
@@ -177,12 +187,24 @@ impl OverlayWindow {
     /// - macOS expects coordinates in points (scaled) for control commands
     /// - Windows expects coordinates in pixels (unscaled)
     pub fn translate_to_global(&self, x: f64, y: f64) -> Position {
-        // This doesn't work in window local click, only works when sharing display
-        // Here in y the menubar heigh is included.
-        let mut x = x * self.display_info.display_extent.width
-            + (self.display_info.display_position.x as f64);
-        let mut y = y * self.display_info.display_extent.height
-            + (self.display_info.display_position.y as f64);
+        let sharing = self.sharing_frame();
+        let (mut x, mut y) = if sharing.extent.width > 0.0 && sharing.extent.height > 0.0 {
+            // Shared content is a window sub-rect of the display.
+            let x = sharing.origin_x
+                + x * sharing.extent.width
+                + self.display_info.display_position.x as f64;
+            let y = sharing.origin_y
+                + y * sharing.extent.height
+                + self.display_info.display_position.y as f64;
+            (x, y)
+        } else {
+            // Full-display share: percentages map across the whole monitor.
+            let x = x * self.display_info.display_extent.width
+                + (self.display_info.display_position.x as f64);
+            let y = y * self.display_info.display_extent.height
+                + (self.display_info.display_position.y as f64);
+            (x, y)
+        };
         /*
          * macOS expects the coords in points (scaled) in control commands while windows
          * expects them unscaled.
@@ -270,6 +292,35 @@ impl OverlayWindow {
         }
     }
 
+    /// Returns the shared-content rectangle in logical (points) coordinates
+    /// relative to the overlay, or `None` when sharing a full display.
+    pub fn sharing_frame_logical(&self) -> Option<Frame> {
+        let sharing = self.sharing_frame();
+        if sharing.extent.width <= 0.0 || sharing.extent.height <= 0.0 {
+            return None;
+        }
+
+        let scale = if self.display_info.display_scale > 0.0 {
+            self.display_info.display_scale
+        } else {
+            1.0
+        };
+
+        // Frame is display-local physical; convert to overlay-local logical in case the
+        // fullscreen overlay origin differs slightly from the monitor origin.
+        let offset_x = self.position.x as f64 - self.display_info.display_position.x as f64;
+        let offset_y = self.position.y as f64 - self.display_info.display_position.y as f64;
+
+        Some(Frame {
+            origin_x: (sharing.origin_x - offset_x) / scale,
+            origin_y: (sharing.origin_y - offset_y) / scale,
+            extent: Extent {
+                width: sharing.extent.width / scale,
+                height: sharing.extent.height / scale,
+            },
+        })
+    }
+
     /// Creates a closure that translates percentage positions (0.0–1.0) to logical pixel positions.
     pub fn create_position_translator(&self) -> impl Fn(Position) -> Position {
         let width = self.display_info.display_extent.width / self.display_info.display_scale;
@@ -286,12 +337,12 @@ impl fmt::Display for OverlayWindow {
         write!(
             f,
             "sharing_window_frame: {}, extent: {}, display_extent: {}, position: {:?}, display_position: {:?}, display_scale: {}",
-            self.sharing_window_frame,
+            self.sharing_frame(),
             self.extent,
             self.display_info.display_extent,
             self.position,
             self.display_info.display_position,
-            self.display_info.display_scale,
+            self.display_info.display_scale
         )
     }
 }

--- a/core/src/screen_selection.rs
+++ b/core/src/screen_selection.rs
@@ -1,0 +1,159 @@
+use crate::capture::sources::{
+    list_displays, list_windows, windows_supported, ListedWindows, ShareableSource,
+};
+use crate::capture::thumbnail::Thumbnail;
+use winit::monitor::MonitorHandle;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenSelectionTab {
+    Screens,
+    Windows,
+}
+
+/// One row/tile in the share picker.
+#[derive(Debug, Clone)]
+pub struct ScreenSelectionItemUi {
+    pub title: String,
+    pub subtitle: Option<String>,
+    pub thumbnail: Option<iced_core::image::Handle>,
+}
+
+/// Snapshot passed to the overlay renderer for the share picker.
+#[derive(Debug, Clone)]
+pub struct ScreenSelectionUi {
+    pub tab: ScreenSelectionTab,
+    pub windows_supported: bool,
+    pub items: Vec<ScreenSelectionItemUi>,
+    pub selected_index: usize,
+    /// Shown on the Windows tab when the list is empty (e.g. missing permission).
+    pub windows_hint: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ScreenSelectionState {
+    pub tab: ScreenSelectionTab,
+    pub displays: Vec<ShareableSource>,
+    pub windows: Vec<ShareableSource>,
+    pub selected_index: usize,
+    pub windows_supported: bool,
+    pub windows_hint: Option<String>,
+}
+
+impl ScreenSelectionState {
+    pub fn new(monitors: &[MonitorHandle]) -> Self {
+        let displays = list_displays(monitors);
+        let windows_supported = windows_supported();
+        let ListedWindows { windows, error } = if windows_supported {
+            list_windows(monitors)
+        } else {
+            ListedWindows {
+                windows: Vec::new(),
+                error: Some("Window sharing is not available on this platform.".to_string()),
+            }
+        };
+        Self {
+            tab: ScreenSelectionTab::Screens,
+            displays,
+            windows,
+            selected_index: 0,
+            windows_supported,
+            windows_hint: error,
+        }
+    }
+
+    pub fn current_sources(&self) -> &[ShareableSource] {
+        match self.tab {
+            ScreenSelectionTab::Screens => &self.displays,
+            ScreenSelectionTab::Windows => &self.windows,
+        }
+    }
+
+    pub fn selected(&self) -> Option<&ShareableSource> {
+        self.current_sources().get(self.selected_index)
+    }
+
+    pub fn move_selection(&mut self, delta: isize) {
+        let len = self.current_sources().len();
+        if len == 0 {
+            self.selected_index = 0;
+            return;
+        }
+        let current = self.selected_index as isize;
+        let next = (current + delta).rem_euclid(len as isize) as usize;
+        self.selected_index = next;
+    }
+
+    pub fn select_index(&mut self, index: usize) -> bool {
+        if index < self.current_sources().len() {
+            self.selected_index = index;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Selects the display matching `monitor_content_id` when on the Screens tab.
+    pub fn select_display_for_monitor(&mut self, monitor_content_id: u64) -> bool {
+        if self.tab != ScreenSelectionTab::Screens {
+            return false;
+        }
+        let Some(index) = self
+            .displays
+            .iter()
+            .position(|source| source.monitor_content_id == monitor_content_id)
+        else {
+            return false;
+        };
+        self.selected_index = index;
+        true
+    }
+
+    pub fn set_tab(&mut self, tab: ScreenSelectionTab) {
+        if tab == ScreenSelectionTab::Windows && !self.windows_supported {
+            return;
+        }
+        if self.tab != tab {
+            self.tab = tab;
+            self.selected_index = 0;
+        }
+    }
+
+    pub fn toggle_tab(&mut self) {
+        if !self.windows_supported {
+            return;
+        }
+        let next = match self.tab {
+            ScreenSelectionTab::Screens => ScreenSelectionTab::Windows,
+            ScreenSelectionTab::Windows => ScreenSelectionTab::Screens,
+        };
+        self.set_tab(next);
+    }
+
+    pub fn ui_snapshot(&self) -> ScreenSelectionUi {
+        ScreenSelectionUi {
+            tab: self.tab,
+            windows_supported: self.windows_supported,
+            items: self
+                .current_sources()
+                .iter()
+                .map(|source| {
+                    let (title, subtitle) = match self.tab {
+                        ScreenSelectionTab::Screens => {
+                            (source.title.clone(), Some("Entire screen".to_string()))
+                        }
+                        ScreenSelectionTab::Windows => {
+                            (source.title.clone(), source.app_name.clone())
+                        }
+                    };
+                    ScreenSelectionItemUi {
+                        title,
+                        subtitle,
+                        thumbnail: source.thumbnail.as_ref().map(Thumbnail::image_handle),
+                    }
+                })
+                .collect(),
+            selected_index: self.selected_index,
+            windows_hint: self.windows_hint.clone(),
+        }
+    }
+}

--- a/core/src/utils/geometry.rs
+++ b/core/src/utils/geometry.rs
@@ -4,7 +4,7 @@ use std::cmp::max;
 use serde::{Deserialize, Serialize};
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, bytemuck::Pod, bytemuck::Zeroable, Serialize, Deserialize)]
 pub struct Extent {
     pub width: f64,
     pub height: f64,
@@ -17,7 +17,7 @@ impl fmt::Display for Extent {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Debug, Copy, Clone, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct Frame {
     pub origin_x: f64,
     pub origin_y: f64,

--- a/core/src/window_manager.rs
+++ b/core/src/window_manager.rs
@@ -325,7 +325,6 @@ impl<'a> WindowManager<'a> {
                 .map_err(|_| WindowManagerError::WindowCreationError)?;
             self.active_monitor_id = Some(target_id);
         } else {
-            entry.gfx.set_screen_selection(true);
             let _ = entry.gfx.window().set_cursor_hittest(true);
         }
         entry.window.set_visible(true);
@@ -416,6 +415,31 @@ impl<'a> WindowManager<'a> {
             .map(|entry| entry.monitor_id.clone())
     }
 
+    pub fn set_selection_cursor(
+        &mut self,
+        window_id: winit::window::WindowId,
+        position: winit::dpi::PhysicalPosition<f64>,
+    ) {
+        if let Some(entry) = self
+            .windows
+            .iter_mut()
+            .find(|entry| entry.window.id() == window_id)
+        {
+            entry.gfx.set_selection_cursor(position);
+        }
+    }
+
+    pub fn handle_selection_click(
+        &mut self,
+        window_id: winit::window::WindowId,
+    ) -> Vec<crate::graphics::graphics_context::iced_renderer::ScreenSelectionMessage> {
+        self.windows
+            .iter_mut()
+            .find(|entry| entry.window.id() == window_id)
+            .map(|entry| entry.gfx.handle_selection_click())
+            .unwrap_or_default()
+    }
+
     pub fn resize_window(
         &mut self,
         window_id: winit::window::WindowId,
@@ -458,6 +482,18 @@ impl<'a> WindowManager<'a> {
         }
     }
 
+    pub fn update_screen_selection_ui(
+        &mut self,
+        ui: Option<crate::screen_selection::ScreenSelectionUi>,
+    ) {
+        for entry in &mut self.windows {
+            if entry.window.is_visible().unwrap_or(false) && self.active_monitor_id.is_none() {
+                entry.gfx.set_screen_selection(ui.clone());
+                entry.gfx.trigger_render();
+            }
+        }
+    }
+
     pub fn focus_window(&self, window_id: winit::window::WindowId) -> bool {
         if let Some(entry) = self
             .windows
@@ -492,10 +528,11 @@ impl<'a> WindowManager<'a> {
         &self,
         current_window_id: winit::window::WindowId,
         direction: ScreenSelectionNavigationDirection,
-    ) -> bool {
+    ) -> Option<winit::window::WindowId> {
         let mut entries: Vec<_> = self
             .windows
             .iter()
+            .filter(|entry| entry.window.is_visible().unwrap_or(false))
             .filter_map(|entry| {
                 let position = entry.window.outer_position().ok()?;
                 let logical_position: LogicalPosition<f64> =
@@ -506,7 +543,7 @@ impl<'a> WindowManager<'a> {
             .collect();
 
         if entries.len() < 2 {
-            return false;
+            return None;
         }
 
         match direction {
@@ -514,23 +551,20 @@ impl<'a> WindowManager<'a> {
             | ScreenSelectionNavigationDirection::Right => {
                 entries.sort_by(|a, b| a.1.total_cmp(&b.1));
                 if entries.windows(2).any(|pair| pair[0].1 == pair[1].1) {
-                    return false;
+                    return None;
                 }
             }
             ScreenSelectionNavigationDirection::Up | ScreenSelectionNavigationDirection::Down => {
                 entries.sort_by(|a, b| a.2.total_cmp(&b.2));
                 if entries.windows(2).any(|pair| pair[0].2 == pair[1].2) {
-                    return false;
+                    return None;
                 }
             }
         }
 
-        let Some(current_index) = entries
+        let current_index = entries
             .iter()
-            .position(|(window_id, _, _)| *window_id == current_window_id)
-        else {
-            return false;
-        };
+            .position(|(window_id, _, _)| *window_id == current_window_id)?;
 
         let target_index = match direction {
             ScreenSelectionNavigationDirection::Left | ScreenSelectionNavigationDirection::Up => {
@@ -545,25 +579,22 @@ impl<'a> WindowManager<'a> {
         };
 
         let target_window_id = entries[target_index].0;
-        let Some(target_entry) = self
+        let target_entry = self
             .windows
             .iter()
-            .find(|entry| entry.window.id() == target_window_id)
-        else {
-            return false;
-        };
+            .find(|entry| entry.window.id() == target_window_id)?;
 
         target_entry.window.focus_window();
         for entry in &self.windows {
             entry.gfx.trigger_render();
         }
 
-        true
+        Some(target_window_id)
     }
 
     pub fn hide_screen_selection(&mut self) {
         for entry in &mut self.windows {
-            entry.gfx.set_screen_selection(false);
+            entry.gfx.set_screen_selection(None);
             #[cfg(target_os = "macos")]
             {
                 entry.window.set_simple_fullscreen(false);

--- a/core/tests/src/screenshare_client.rs
+++ b/core/tests/src/screenshare_client.rs
@@ -18,7 +18,7 @@ pub fn connect_socket() -> io::Result<(SocketSender, EventSocket)> {
 
 /// Returns the screen content id to capture, read from the `HOPP_TEST_SCREEN_ID`
 /// environment variable. Falls back to `0` if unset.
-fn screen_id() -> u32 {
+fn screen_id() -> u64 {
     env::var("HOPP_TEST_SCREEN_ID")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -67,7 +67,7 @@ pub fn call_end(sender: &SocketSender) -> io::Result<()> {
 pub fn request_screenshare(
     sender: &SocketSender,
     event_socket: &EventSocket,
-    content_id: u32,
+    content_id: u64,
     width: f64,
     height: f64,
 ) -> io::Result<()> {
@@ -77,6 +77,8 @@ pub fn request_screenshare(
             id: content_id,
         },
         resolution: Extent { width, height },
+        monitor_id: Some(content_id),
+        window_frame: None,
     });
     sender.send(message).unwrap();
 


### PR DESCRIPTION
## Summary
- Adds window sharing alongside full-screen share, with a Meet/Zoom-style picker (Entire Screen / Window tabs, thumbnails, click-to-share).
- Tracks shared windows with rounded corner marks that follow window move/resize, using Quartz bounds with SCWindow fallback.
- Brings the shared app to the front on confirm so the sharer can keep interacting under the click-through overlay.

Done by AI, it was a test to see if AI can handle it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a screen-sharing picker for displays and windows, with tabs, previews, titles, and app details.
  * Added support for selecting and sharing individual windows on macOS and Windows.
  * Added live window-bound tracking so overlays and markers remain aligned as windows move or resize.
  * Added keyboard and mouse navigation for choosing a sharing source.
* **Bug Fixes**
  * Improved handling of unsupported window sharing and screen-capture permission issues.
  * Improved capture reliability for large source identifiers and changing capture regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->