### PR TITLE
fix: re-enter room

### DIFF
--- a/tauri/src-tauri/src/main.rs
+++ b/tauri/src-tauri/src/main.rs
@@ -1102,9 +1102,6 @@ fn forward_core_events(events_rx: std_mpsc::Receiver<Message>, app: tauri::AppHa
             }
             Message::CallEnded => {
                 log::info!("forward_core_events: call ended");
-                if let Err(e) = app.emit("core_call_ended", &()) {
-                    log::error!("forward_core_events: failed to emit call ended: {e:?}");
-                }
                 let data = app.state::<Mutex<AppData>>();
                 let mut data = data.lock().unwrap();
                 data.call_active = false;
@@ -1123,7 +1120,12 @@ fn forward_core_events(events_rx: std_mpsc::Receiver<Message>, app: tauri::AppHa
                         suppress.store(false, Ordering::Relaxed);
                     });
                 }
+                #[cfg(not(target_os = "macos"))]
+                drop(data);
                 shortcuts::unregister_call_shortcuts(&app);
+                if let Err(e) = app.emit("core_call_ended", &()) {
+                    log::error!("forward_core_events: failed to emit call ended: {e:?}");
+                }
             }
             Message::ControllerDrawPersistChanged(persist) => {
                 log::info!("forward_core_events: controller draw persist changed: {persist}");

--- a/tauri/src/components/ui/participant-row-wo-livekit.tsx
+++ b/tauri/src/components/ui/participant-row-wo-livekit.tsx
@@ -14,7 +14,7 @@ import { HoppAvatar } from "@/components/ui/hopp-avatar";
 import { tauriUtils } from "@/windows/window-utils";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAPI } from "@/services/query";
-import { useEndCall } from "@/lib/hooks";
+import { endCallAndWait, useEndCall } from "@/lib/hooks";
 
 const TruncatedName = ({ text, className }: { text: string; className?: string }) => {
   const textRef = useRef<HTMLDivElement>(null);
@@ -104,8 +104,7 @@ export const ParticipantRow = (props: {
       });
 
       if (callTokens) {
-        endCall();
-        await sleep(500);
+        await endCallAndWait(endCall);
       }
 
       const tokens = await getRoomTokens({

--- a/tauri/src/lib/hooks.ts
+++ b/tauri/src/lib/hooks.ts
@@ -1,4 +1,5 @@
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
+import { once } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 import hotkeys from "hotkeys-js";
 import useStore, { ParticipantRole } from "@/store/store";
@@ -9,6 +10,7 @@ import { sounds } from "@/constants/sounds";
 import { useFetchClient } from "@/services/query";
 
 const appWindow = getCurrentWebviewWindow();
+const CALL_END_TIMEOUT_MS = 5_000;
 
 /**
  * Hook to detect and listen for system theme changes (light/dark mode).
@@ -142,4 +144,26 @@ export function useEndCall() {
   }, [callTokens, setCallTokens, user, posthog, fetchClient]);
 
   return endCall;
+}
+
+export async function endCallAndWait(endCall: () => void) {
+  let resolveCallEnded = () => {};
+  const callEnded = new Promise<void>((resolve) => {
+    resolveCallEnded = () => resolve();
+  });
+  const unlisten = await once("core_call_ended", resolveCallEnded);
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    endCall();
+    await Promise.race([
+      callEnded,
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("Timed out waiting for core call cleanup")), CALL_END_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    unlisten();
+  }
 }

--- a/tauri/src/windows/main-window/tabs/Rooms.tsx
+++ b/tauri/src/windows/main-window/tabs/Rooms.tsx
@@ -33,7 +33,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { HiMagnifyingGlass, HiOutlinePencil, HiOutlineTrash } from "react-icons/hi2";
 import { useState } from "react";
 import doorImage from "@/assets/door.png";
-import { useEndCall } from "@/lib/hooks";
+import { endCallAndWait, useEndCall } from "@/lib/hooks";
 
 type Room = components["schemas"]["Room"];
 
@@ -83,7 +83,7 @@ const RoomPresenceAvatars = ({
                         alt={`${info.first_name} ${info.last_name}`}
                         className="size-full object-cover"
                       />
-                      : <span className="text-[8px] font-medium text-emerald-700">
+                    : <span className="text-[8px] font-medium text-emerald-700">
                         {info.first_name[0]}
                         {info.last_name[0]}
                       </span>
@@ -135,7 +135,7 @@ const RoomPresenceAvatars = ({
 };
 
 export const Rooms = () => {
-  const { authToken, callTokens, setCallTokens, teammates, user } = useStore();
+  const { authToken, callTokens, setCallTokens, setTab, teammates, user } = useStore();
   const [searchQuery, setSearchQuery] = useState("");
   const [filteredRooms, setFilteredRooms] = useState<Room[]>([]);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -264,12 +264,11 @@ export const Rooms = () => {
 
   const handleJoinRoom = useCallback(
     async (room: Room) => {
-      if (isJoiningRoom) return;
-
-      // End existing call if there is one
-      if (callTokens) {
-        endCall();
+      if (callTokens?.room?.id === room.id) {
+        setTab("call");
+        return;
       }
+      if (isJoiningRoom) return;
 
       setIsJoiningRoom(true);
       joiningToastTimeout.current = setTimeout(() => {
@@ -277,6 +276,10 @@ export const Rooms = () => {
       }, 300);
 
       try {
+        if (callTokens) {
+          await endCallAndWait(endCall);
+        }
+
         const tokens = await getRoomTokens({
           params: {
             path: {
@@ -325,7 +328,7 @@ export const Rooms = () => {
         setIsJoiningRoom(false);
       }
     },
-    [getRoomTokens, callTokens, setCallTokens, endCall, isJoiningRoom],
+    [getRoomTokens, callTokens, setCallTokens, setTab, endCall, isJoiningRoom],
   );
 
   useEffect(() => {
@@ -404,7 +407,7 @@ export const Rooms = () => {
                   presenceAvatars={
                     presenceIds.length > 0 ?
                       <RoomPresenceAvatars participantIds={presenceIds} getParticipantInfo={getParticipantInfo} />
-                      : undefined
+                    : undefined
                   }
                   cornerIcon={
                     <DropdownMenu>
@@ -439,7 +442,7 @@ export const Rooms = () => {
               );
             })}
           </div>
-          : <EmptyRoomsState onCreateRoomClick={() => setIsCreateDialogOpen(true)} isLoadingRooms={isLoadingRooms} />}
+        : <EmptyRoomsState onCreateRoomClick={() => setIsCreateDialogOpen(true)} isLoadingRooms={isLoadingRooms} />}
         <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
           <DialogContent container={document.getElementById("app-body")}>
             <DialogHeader>
@@ -522,4 +525,3 @@ const EmptyRoomsState = ({
     </div>
   );
 };
-


### PR DESCRIPTION
Fixes a bug where a user when clicking the room they were already in, they were kicked out of the room.

Also made the frontend now waits for the backend to emit the call ended ack. If a user decides to change rooms now this is possible with a single click.

Closes #366 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call transitions when switching between rooms by waiting for the current call to end before starting another.
  * Prevented unnecessary call re-initialization when rejoining the room already in use.
  * Improved call cleanup and event handling across supported platforms.
  * Added a timeout safeguard to prevent room joining from waiting indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->