### PR TITLE
improvement: stop screen-share from camera window

### DIFF
--- a/core/src/window/camera_window.rs
+++ b/core/src/window/camera_window.rs
@@ -158,6 +158,7 @@ pub enum CameraWindowError {
 pub enum CameraMessage {
     MicToggle,
     ScreenShare,
+    OpenScreenSharePicker,
     VideoToggle,
     EndCall,
     ToggleSelfVisibility,
@@ -718,11 +719,25 @@ impl CameraWindow {
             state.camera_dropdown_open,
         );
 
+        let is_screensharing = participants
+            .read()
+            .ok()
+            .and_then(|participants| {
+                participants
+                    .get("local")
+                    .map(ParticipantInfo::is_screensharing)
+            })
+            .unwrap_or(false);
+        let screen_bg_color = if is_screensharing {
+            ColorToken::Green400.to_color()
+        } else {
+            ColorToken::Gray400.to_color()
+        };
         let screen_button = split_button(
             ICON_SCREEN_SHARE,
-            ColorToken::Gray400.to_color(),
+            screen_bg_color,
             CameraMessage::ScreenShare,
-            None,
+            Some(CameraMessage::OpenScreenSharePicker),
             false,
         );
 
@@ -945,12 +960,35 @@ impl CameraWindow {
                 }
             }
             CameraMessage::ScreenShare => {
-                log::info!("CameraWindow: screen share -> GetAvailableContent");
-                if let Err(e) = self
+                let is_screensharing = self
+                    .participants
+                    .read()
+                    .ok()
+                    .and_then(|participants| {
+                        participants
+                            .get("local")
+                            .map(ParticipantInfo::is_screensharing)
+                    })
+                    .unwrap_or(false);
+
+                let event = if is_screensharing {
+                    UserEvent::StopScreenShare
+                } else {
+                    UserEvent::GetAvailableContent
+                };
+
+                log::info!("CameraWindow: screen share toggle -> {:?}", event);
+                if let Err(error) = self.event_loop_proxy.send_event(event) {
+                    log::error!("CameraWindow: failed to send screen share event: {error:?}");
+                }
+            }
+            CameraMessage::OpenScreenSharePicker => {
+                log::info!("CameraWindow: opening screen share picker");
+                if let Err(error) = self
                     .event_loop_proxy
                     .send_event(UserEvent::GetAvailableContent)
                 {
-                    log::error!("CameraWindow: failed to send GetAvailableContent event: {e:?}");
+                    log::error!("CameraWindow: failed to open screen share picker: {error:?}");
                 }
             }
             CameraMessage::VideoToggle => {

--- a/core/src/window_manager.rs
+++ b/core/src/window_manager.rs
@@ -499,12 +499,40 @@ impl<'a> WindowManager<'a> {
             log::info!("{:?}", res);
         }
 
-        if let Some(monitor) = event_loop
-            .primary_monitor()
+        #[cfg(target_os = "macos")]
+        let cursor_monitor = ScreenshareFunctions::cursor_position().and_then(|cursor| {
+            monitors
+                .iter()
+                .find(|monitor| {
+                    let scale = monitor.scale_factor();
+                    let position = monitor.position().to_logical::<f64>(scale);
+                    let size = monitor.size().to_logical::<f64>(scale);
+
+                    cursor.x >= position.x
+                        && cursor.x < position.x + size.width
+                        && cursor.y >= position.y
+                        && cursor.y < position.y + size.height
+                })
+                .cloned()
+        });
+
+        #[cfg(not(target_os = "macos"))]
+        let cursor_monitor: Option<MonitorHandle> = None;
+
+        let active_monitor = self.active_monitor_id.as_ref().and_then(|active_id| {
+            monitors
+                .iter()
+                .find(|monitor| ScreenshareFunctions::get_monitor_id(monitor) == *active_id)
+                .cloned()
+        });
+
+        if let Some(monitor) = cursor_monitor
+            .or(active_monitor)
+            .or_else(|| event_loop.primary_monitor())
             .or_else(|| monitors.first().cloned())
         {
             if !self.focus_monitor(&monitor) {
-                log::warn!("show_screen_selection: failed to focus primary monitor window");
+                log::warn!("show_screen_selection: failed to focus monitor window");
             }
         }
     }
@@ -613,14 +641,22 @@ impl<'a> WindowManager<'a> {
     }
 
     pub fn hide_screen_selection(&mut self) {
+        let active_monitor_id = self.active_monitor_id.clone();
         for entry in &mut self.windows {
             entry.gfx.set_screen_selection(None);
+            let _ = entry.window.set_cursor_hittest(false);
+
+            if active_monitor_id.as_ref() == Some(&entry.monitor_id) {
+                entry.window.set_visible(true);
+                entry.gfx.trigger_render();
+                continue;
+            }
+
             #[cfg(target_os = "macos")]
             {
                 entry.window.set_simple_fullscreen(false);
                 remove_miniaturizable_style(&entry.window);
             }
-            let _ = entry.window.set_cursor_hittest(false);
             entry.window.set_visible(false);
             entry.gfx.resize(winit::dpi::PhysicalSize::new(1, 1));
         }


### PR DESCRIPTION
The camera window allows to also stop the screen-share other than just triggering the content picker.

Also this commit fixes a bug where the content picker was clearing the screen-share overlay if it was cancelled during a screen-share.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved screen sharing controls with clearer active-sharing feedback.
  * Added a dropdown option to choose screen-sharing content.
  * Automatically prioritizes the monitor containing the cursor when selecting a screen on macOS.

* **Bug Fixes**
  * Improved monitor window handling when screen selection is hidden, preserving the active monitor view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->